### PR TITLE
Add AI tmux workspace to Go submap and Work launcher

### DIFF
--- a/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
+++ b/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
@@ -89,6 +89,7 @@ function M.get_sessions()
 
     ["💼 Work"] = {
       betterbird(),
+      tmuxifier({ session = "ai", monitor = 4, ws = 2 }),
       { monitor = 2, ws = 1, cmd = "qutebrowser" },
       { monitor = 3, ws = 1, cmd = "firefox --new-window" },
       tmuxifier({ session = "uphill" }),

--- a/home/hypr/.config/hypr/keymaps/submaps/go/init.lua
+++ b/home/hypr/.config/hypr/keymaps/submaps/go/init.lua
@@ -29,6 +29,7 @@ Submap.define({
       -- stylua: ignore start
       { "TAB",       Workspace.focus_last(),                "Last Workspace" },
       { "A",         Menu.drun(),                           "Apps Launcher" },
+      { "SHIFT + A", Apps.focus_or_launch(APP.tmux_ai),     "Tmuxifier AI" },
       { "B",         Apps.focus_or_launch(APP.firefox),     "Browser" },
       { "C",         Apps.focus_or_launch(APP.tmux_config), "Tmuxifier Config" },
       { "SHIFT + C", Apps.focus_or_launch(APP.tmux_civil),  "Tmuxifier Civil" },

--- a/home/hypr/.config/hypr/lib/actions/apps.lua
+++ b/home/hypr/.config/hypr/lib/actions/apps.lua
@@ -23,6 +23,7 @@ Apps.map = {
   slack       = { program = "slack",       class = "Slack" },
   steam       = { program = "steam",       class = "steam",                         cmd = "steam"},
   terminal    = { program = TERM,          exclude_title = "Tmux" },
+  tmux_ai     = { program = TERM,          title = "Tmux AI",                       cmd = TERM_CMD .. " -e tmuxifier load-session ai" },
   tmux_config = { program = TERM,          title = "Tmux Config",                   cmd = TERM_CMD .. " -e tmuxifier load-session config" },
   tmux_civil  = { program = TERM,          title = "Tmux Civil Communicator",       cmd = TERM_CMD .. " -e tmuxifier load-session cc-dev" },
   tmux_uphill = { program = TERM,          title = "Tmux UpHill",                   cmd = TERM_CMD .. " -e tmuxifier load-session uphill" },

--- a/home/tmux/tmuxifier-layouts/ai.session.sh
+++ b/home/tmux/tmuxifier-layouts/ai.session.sh
@@ -1,0 +1,32 @@
+# tmux/tmuxifier-layouts/ai.session.sh
+# Set a custom session root path. Default is `$HOME`.
+# Must be called before `initialize_session`.
+session_root "$HOME/Development/"
+
+# Check if tmux is running, and start it if not
+if ! pgrep tmux >/dev/null; then
+  tmux start-server
+fi
+
+session_name="AI"
+
+# Create session with specified name if it does not already exist. If no
+# argument is given, session name will be based on layout file name.
+if initialize_session "$session_name"; then
+  # Make the outer terminal/window title predictable.
+  tmux set-option -t "$session_name" set-titles on
+  tmux set-option -t "$session_name" set-titles-string "Tmux $session_name"
+
+  new_window "Claude"
+  run_cmd "cd $session_root"
+  run_cmd "claude"
+
+  new_window "Codex"
+  run_cmd "cd $session_root"
+  run_cmd "codex"
+
+  select_window 1
+fi
+
+# Finalize session creation and switch/attach to it.
+finalize_and_go_to_session


### PR DESCRIPTION
Closes #2

## Summary

- add an `AI` tmuxifier session rooted at `~/Development/`
- launch Claude and Codex in dedicated tmux windows
- add `tmux_ai` to the shared Hyprland app map
- bind `Shift+A` in the Go submap to focus or launch the AI session
- launch AI from the Work preset on monitor 4, workspace offset 2, immediately after Betterbird's workspace

## Implementation notes

The Work preset already places Betterbird on monitor 4 / workspace offset 1. The AI session therefore uses the same monitor and the next workspace offset (`2`) without adding new launcher machinery.

The tmuxifier layout enables the existing predictable `Tmux AI` terminal title convention, allowing the Go binding to use the same `Apps.focus_or_launch` path as the existing Config, Civil, and UpHill tmux sessions.

## Validation

- compared branch against `main`: 4 expected files changed
- no unrelated files modified
- follows existing tmuxifier and Hyprland app-action conventions

Runtime validation still requires Hyprland/tmuxifier on the target machine.