### PR TITLE
Add gdu keybind to Yazi

### DIFF
--- a/home/yazi/.config/yazi/keymap.toml
+++ b/home/yazi/.config/yazi/keymap.toml
@@ -48,6 +48,7 @@ prepend_keymap = [
   { on = [ "g", "z", ], run = "cd /home/roberth/.local/state/yazi", desc = "Go to Yazi debug log" },
 
   # In...
+  { on = ["i", "d"], run = "shell --block -- gdu .", desc = "Disk usage" },
   { on = ["i", "e"], run = "shell -- thunar .", desc = "Open in GUI Explorer" },
   { on = ["i", "i"], run = 'shell --block -- stat %h; echo; file %h; echo; read -n 1 -s -r -p "Press any key..."', desc = "Inspect file" },
   { on = ["i", "r"], run = "shell --block -- %h", desc = "Run executable" },


### PR DESCRIPTION
Closes #4

## Summary

- add `i d` under the existing Yazi `In...` keymap namespace
- run `gdu .` from Yazi's current directory
- block Yazi while `gdu` is active and return to the existing session when it exits

## Validation

- only `home/yazi/.config/yazi/keymap.toml` is changed
- follows the existing `shell --block -- ...` convention used by neighboring keybinds

Runtime validation requires Yazi and `gdu` on the target machine.