### PR TITLE
Add Mergiraf command to Lazygit

### DIFF
--- a/home/lazygit/.config/lazygit/config.yml
+++ b/home/lazygit/.config/lazygit/config.yml
@@ -37,5 +37,10 @@ os:
   edit: "~/.config/lazygit/lazygit-edit {{filename}}"
   editAtLine: "~/.config/lazygit/lazygit-edit {{filename}} {{line}}"
   editAtLineAndWait: "~/.config/lazygit/lazygit-edit {{filename}} {{line}}"
+customCommands:
+  - key: '<ctrl+g>'
+    context: files
+    command: 'mergiraf solve {{ .SelectedFile.Name | quote }}'
+    description: 'Resolve with Mergiraf'
 disableStartupPopups: true
 notARepository: skip


### PR DESCRIPTION
Closes #6

## Summary

- add a Lazygit custom command in the Files context
- bind `<ctrl+g>` to run `mergiraf solve` on the selected file
- keep the result unstaged so conflicts can be reviewed before staging

## Scope

This does not configure Mergiraf as a global Git merge driver; it remains an explicit Lazygit action.