### PR TITLE
Add Neovim mergetool command to Lazygit

### DIFF
--- a/home/lazygit/.config/lazygit/config.yml
+++ b/home/lazygit/.config/lazygit/config.yml
@@ -42,5 +42,9 @@ customCommands:
     context: files
     command: 'mergiraf solve {{ .SelectedFile.Name | quote }}'
     description: 'Resolve with Mergiraf'
+  - key: '<ctrl+t>'
+    context: files
+    command: 'git mergetool --no-prompt -- {{ .SelectedFile.Name | quote }}'
+    description: 'Open merge tool'
 disableStartupPopups: true
 notARepository: skip

--- a/home/lazygit/.config/lazygit/config.yml
+++ b/home/lazygit/.config/lazygit/config.yml
@@ -44,7 +44,7 @@ customCommands:
     description: 'Resolve with Mergiraf'
   - key: '<ctrl+t>'
     context: files
-    command: 'git mergetool --no-prompt -- {{ .SelectedFile.Name | quote }}'
-    description: 'Open merge tool'
+    command: 'git mergetool --no-prompt --tool=nvimdiff -- {{ .SelectedFile.Name | quote }}'
+    description: 'Open Neovim merge tool'
 disableStartupPopups: true
 notARepository: skip


### PR DESCRIPTION
Closes #9

## Summary

- add a Lazygit Files-context command on `<ctrl+t>`
- run `git mergetool --no-prompt --tool=nvimdiff --` for the selected file
- explicitly use Neovim's `nvimdiff` mergetool instead of relying on global Git mergetool configuration
- keep the existing `<ctrl+g>` Mergiraf command unchanged

## Workflow

Use `<ctrl+g>` for Mergiraf structural resolution first, then `<ctrl+t>` to open Neovim for any conflicts that remain.