### PR TITLE
Add global AI command workspace and voice submap

### DIFF
--- a/home/hypr/.config/hypr/config/autostart/init.lua
+++ b/home/hypr/.config/hypr/config/autostart/init.lua
@@ -1,5 +1,6 @@
 -- home/hypr/.config/hypr/config/system/autostart.lua
 
+local AI = require("lib.actions.ai")
 local Config = require("config")
 local TERM = Config.app.term
 
@@ -28,6 +29,7 @@ local function run()
   -- hl.exec_cmd("hyprpm reload")                                                            -- Load plugins
   hl.exec_cmd("lua ~/.config/hypr/extensions/wallpaper/init.lua")
   hl.exec_cmd("voxtype setup systemd")
+  AI.launch()
 end
 
 return run

--- a/home/hypr/.config/hypr/config/rules/init.lua
+++ b/home/hypr/.config/hypr/config/rules/init.lua
@@ -138,6 +138,13 @@ local set_window_rules = function()
     focus_on_activate = true,
     fullscreen = true,
   })
+
+  -- AI workspace
+  hl.window_rule({
+    name = "ai-workspace",
+    match = { class = "^(ai-workspace)$" },
+    workspace = "special:agents silent",
+  })
 end
 
 --- Toggles browser opacity when a screenshare session starts or stops.

--- a/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
+++ b/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
@@ -89,7 +89,6 @@ function M.get_sessions()
 
     ["💼 Work"] = {
       betterbird(),
-      tmuxifier({ session = "ai", monitor = 4, ws = 2 }),
       { monitor = 2, ws = 1, cmd = "qutebrowser" },
       { monitor = 3, ws = 1, cmd = "firefox --new-window" },
       tmuxifier({ session = "uphill" }),

--- a/home/hypr/.config/hypr/keymaps/submaps/ai/init.lua
+++ b/home/hypr/.config/hypr/keymaps/submaps/ai/init.lua
@@ -1,0 +1,35 @@
+--- AI command submap
+--- Tool keys toggle VoxType recording on/off.
+--- Bare keys submit the prompt. Ctrl variants prefill without submitting.
+--- The submap stays active until `.` or Escape exits it.
+
+local AI = require("lib.actions.ai") --- @class AI
+local Config = require("config") --- @class Config
+local Submap = require("lib.key.submap") --- @class Submap
+
+Submap.define({
+  name = "AI",
+  desc = "+AI",
+  enter = Config.leader .. " + SHIFT + A",
+
+  escape = "reset",
+  catchall = "stay",
+
+  -- stylua: ignore
+  binds = {
+    { "PERIOD",     Submap.reset,                                                   "Exit AI" },
+    { "A",          AI.show,                                                        "AI Workspace" },
+
+    { "G",          function() AI.toggle("use gog to", true) end,                  "Gog" },
+    { "CTRL + G",   function() AI.toggle("use gog to", false) end,                 "Gog (Prefill)" },
+
+    { "H",          function() AI.toggle("use gh to", true) end,                   "GitHub" },
+    { "CTRL + H",   function() AI.toggle("use gh to", false) end,                  "GitHub (Prefill)" },
+
+    { "B",          function() AI.toggle("use agent-browser to", true) end,        "Browser" },
+    { "CTRL + B",   function() AI.toggle("use agent-browser to", false) end,       "Browser (Prefill)" },
+
+    { "S",          function() AI.toggle("use the shell and available system tools to", true) end,  "System" },
+    { "CTRL + S",   function() AI.toggle("use the shell and available system tools to", false) end, "System (Prefill)" },
+  },
+}).setup()

--- a/home/hypr/.config/hypr/keymaps/submaps/ai/init.lua
+++ b/home/hypr/.config/hypr/keymaps/submaps/ai/init.lua
@@ -14,11 +14,21 @@ Submap.define({
 
   escape = "reset",
   catchall = "stay",
+  on_enter = function()
+    if AI.is_visible() then
+      AI.hide()
+      Submap.reset()
+    else
+      AI.show()
+    end
+  end,
+  on_exit = AI.finish,
 
   -- stylua: ignore
   binds = {
-    { "PERIOD",     Submap.reset,                                                   "Exit AI" },
-    { "A",          AI.show,                                                        "AI Workspace" },
+    { "PERIOD",     Submap.reset,                                                  "Exit AI" },
+    { "X",          function() AI.send_text("/clear") end,          "Clear" },
+    { "BACKSPACE",  AI.cancel,                                      "Cancel Recording" },
 
     { "G",          function() AI.toggle("use gog to", true) end,                  "Gog" },
     { "CTRL + G",   function() AI.toggle("use gog to", false) end,                 "Gog (Prefill)" },

--- a/home/hypr/.config/hypr/keymaps/submaps/init.lua
+++ b/home/hypr/.config/hypr/keymaps/submaps/init.lua
@@ -1,6 +1,7 @@
 --- Submap keybinds
 
 require("keymaps.submaps.apps")
+require("keymaps.submaps.ai")
 require("keymaps.submaps.go")
 require("keymaps.submaps.system")
 require("keymaps.submaps.delete")

--- a/home/hypr/.config/hypr/lib/actions/ai.lua
+++ b/home/hypr/.config/hypr/lib/actions/ai.lua
@@ -1,0 +1,113 @@
+--- AI workspace and voice command actions.
+
+local Config = require("config") --- @class Config
+
+local AI = {
+  recording = false,
+  prefix = nil,
+  submit = true,
+  pending_show = false,
+}
+
+local AI_CLASS = "ai-workspace"
+local AI_WORKSPACE = "ai"
+local TRANSCRIPT_FILE = (os.getenv("XDG_RUNTIME_DIR") or "/tmp") .. "/ai-voice-command.txt"
+local AI_SEND = "~/.config/hypr/scripts/ai-send.sh"
+
+--- @param value string
+--- @return string
+local function shell_quote(value)
+  return "'" .. value:gsub("'", "'\\''") .. "'"
+end
+
+--- @return boolean
+local function window_exists()
+  return #hl.get_windows({ class = AI_CLASS }) > 0
+end
+
+--- @return boolean
+local function workspace_visible()
+  for _, monitor in pairs(hl.get_monitors()) do
+    local workspace = monitor.active_special_workspace
+    if workspace and workspace.name == "special:" .. AI_WORKSPACE then return true end
+  end
+
+  return false
+end
+
+--- @param window any|string
+local function show_workspace(window)
+  if not workspace_visible() then hl.dispatch(hl.dsp.workspace.toggle_special(AI_WORKSPACE)) end
+  hl.dispatch(hl.dsp.focus({ window = window }))
+end
+
+function AI.launch()
+  if window_exists() then return end
+
+  hl.exec_cmd(Config.app.term_cmd .. " --class " .. AI_CLASS .. " -e tmuxifier load-session ai", {
+    workspace = "special:" .. AI_WORKSPACE .. " silent",
+  })
+end
+
+function AI.show()
+  local windows = hl.get_windows({ class = AI_CLASS })
+  if #windows > 0 then
+    show_workspace(windows[1])
+    return
+  end
+
+  AI.pending_show = true
+  AI.launch()
+end
+
+hl.on("window.open", function(window)
+  if not AI.pending_show or window.class ~= AI_CLASS then return end
+
+  AI.pending_show = false
+  show_workspace(window)
+end)
+
+local function start_recording(prefix, submit)
+  AI.recording = true
+  AI.prefix = prefix
+  AI.submit = submit
+
+  os.remove(TRANSCRIPT_FILE)
+  hl.exec_cmd("voxtype record start --file=" .. shell_quote(TRANSCRIPT_FILE))
+end
+
+local function finish_recording()
+  hl.exec_cmd("voxtype record stop")
+
+  local prefix = AI.prefix or ""
+  local mode = AI.submit and "submit" or "prefill"
+
+  AI.recording = false
+  AI.prefix = nil
+  AI.submit = true
+
+  hl.exec_cmd(string.format(
+    "%s %s %s %s",
+    AI_SEND,
+    shell_quote(TRANSCRIPT_FILE),
+    shell_quote(prefix),
+    mode
+  ))
+
+  AI.show()
+end
+
+--- Toggle VoxType recording for a tool-specific prompt prefix.
+--- Press once to start recording; press again to stop and send/prefill.
+--- @param prefix string
+--- @param submit boolean
+function AI.toggle(prefix, submit)
+  if AI.recording then
+    finish_recording()
+    return
+  end
+
+  start_recording(prefix, submit)
+end
+
+return AI

--- a/home/hypr/.config/hypr/lib/actions/ai.lua
+++ b/home/hypr/.config/hypr/lib/actions/ai.lua
@@ -1,115 +1,192 @@
 --- AI workspace and voice command actions.
+--- Recording state comes from the voxtype daemon, not a local boolean, so it can't desync from other binds/restarts.
 
 local Config = require("config") --- @class Config
+local Scripts = require("lib.scripts") --- @class Scripts
+local Window = require("lib.actions.window") --- @class WindowActions
 
-local AI = {
-  recording = false,
-  prefix = nil,
-  submit = true,
-  pending_show = false,
-}
+local AI = {}
+
+local RUNTIME_DIR = os.getenv("XDG_RUNTIME_DIR") or "/tmp"
+local VOXTYPE_STATE_FILE = RUNTIME_DIR .. "/voxtype/state"
+local AI_VOICE_DIR = RUNTIME_DIR .. "/ai-voice"
+local SESSION_FILE = AI_VOICE_DIR .. "/session"
 
 local AI_CLASS = "ai-workspace"
-local AI_WORKSPACE = "ai"
-local TRANSCRIPT_FILE = (os.getenv("XDG_RUNTIME_DIR") or "/tmp") .. "/ai-voice-command.txt"
-local AI_SEND = "~/.config/hypr/scripts/ai-send.sh"
+local AI_WORKSPACE = "agents"
+local AI_TMUXIFIER_SESSION = "ai"
+local AI_TMUX_TARGET = "AI:Claude"
 
 --- @param value string
 --- @return string
-local function shell_quote(value)
-  return "'" .. value:gsub("'", "'\\''") .. "'"
-end
+local function shell_quote(value) return "'" .. value:gsub("'", "'\\''") .. "'" end
 
 --- @param command string
---- @param rules table|nil
-local function exec(command, rules)
-  hl.dispatch(hl.dsp.exec_cmd(command, rules))
-end
+local function exec(command) hl.dispatch(hl.dsp.exec_cmd(command)) end
+
+--- @param message string
+local function notify(message) exec("notify-send " .. shell_quote("AI") .. " " .. shell_quote(message)) end
 
 --- @return boolean
-local function window_exists()
-  return #hl.get_windows({ class = AI_CLASS }) > 0
-end
+local function window_exists() return #hl.get_windows({ class = AI_CLASS }) > 0 end
 
 --- @return boolean
 local function workspace_visible()
-  for _, monitor in pairs(hl.get_monitors()) do
-    local workspace = monitor.active_special_workspace
-    if workspace and workspace.name == "special:" .. AI_WORKSPACE then return true end
-  end
-
-  return false
+  local w = hl.get_active_special_workspace()
+  return w ~= nil and w.name == "special:" .. AI_WORKSPACE
 end
 
---- @param window any|string
-local function show_workspace(window)
-  if not workspace_visible() then hl.dispatch(hl.dsp.workspace.toggle_special(AI_WORKSPACE)) end
-  hl.dispatch(hl.dsp.focus({ window = window }))
+--- idle | recording | transcribing, read straight from voxtype's state file.
+--- @return string
+local function voxtype_state()
+  local f = io.open(VOXTYPE_STATE_FILE, "r")
+  if not f then return "idle" end
+  local line = f:read("*l")
+  f:close()
+  return line or "idle"
+end
+
+--- @param prefix string
+--- @param submit boolean
+--- @param transcript_path string
+local function write_session(prefix, submit, transcript_path)
+  os.execute("mkdir -p " .. shell_quote(AI_VOICE_DIR))
+  local f = io.open(SESSION_FILE, "w")
+  if not f then return end
+  f:write(prefix, "\n", submit and "submit" or "prefill", "\n", transcript_path, "\n")
+  f:close()
+end
+
+--- @return { prefix: string, mode: string, transcript_path: string }|nil
+local function read_session()
+  local f = io.open(SESSION_FILE, "r")
+  if not f then return nil end
+  local prefix = f:read("*l")
+  local mode = f:read("*l")
+  local transcript_path = f:read("*l")
+  f:close()
+  if not (prefix and mode and transcript_path) then return nil end
+  return { prefix = prefix, mode = mode, transcript_path = transcript_path }
+end
+
+local function clear_session() os.remove(SESSION_FILE) end
+
+--- Headless so tmuxifier's attach step fails fast instead of hanging; session still gets created.
+local function ensure_tmux_session()
+  os.execute("tmuxifier load-session " .. AI_TMUXIFIER_SESSION .. " </dev/null >/dev/null 2>&1")
 end
 
 function AI.launch()
+  ensure_tmux_session()
   if window_exists() then return end
 
-  exec(Config.app.term_cmd .. " --class " .. AI_CLASS .. " -e tmuxifier load-session ai", {
-    workspace = "special:" .. AI_WORKSPACE .. " silent",
-  })
+  exec(Config.app.term_cmd .. " --class " .. AI_CLASS .. " -e tmuxifier load-session " .. AI_TMUXIFIER_SESSION)
 end
 
 function AI.show()
+  if not workspace_visible() then Window.toggle_special(AI_WORKSPACE)() end
+
   local windows = hl.get_windows({ class = AI_CLASS })
   if #windows > 0 then
-    show_workspace(windows[1])
-    return
+    hl.dispatch(hl.dsp.focus({ window = windows[1] }))
+  else
+    AI.launch()
   end
-
-  AI.pending_show = true
-  AI.launch()
 end
 
-hl.on("window.open", function(window)
-  if not AI.pending_show or window.class ~= AI_CLASS then return end
-
-  AI.pending_show = false
-  show_workspace(window)
-end)
-
-local function start_recording(prefix, submit)
-  AI.recording = true
-  AI.prefix = prefix
-  AI.submit = submit
-
-  os.remove(TRANSCRIPT_FILE)
-  exec("voxtype record start --file=" .. shell_quote(TRANSCRIPT_FILE))
+function AI.hide()
+  if workspace_visible() then Window.toggle_special(AI_WORKSPACE)() end
 end
 
-local function finish_recording()
-  exec("voxtype record stop")
+AI.is_visible = workspace_visible
 
-  local prefix = AI.prefix or ""
-  local mode = AI.submit and "submit" or "prefill"
+--- Paste text straight into the tmux target and submit, bypassing voxtype entirely.
+--- @param text string
+function AI.send_text(text)
+  ensure_tmux_session()
 
-  AI.recording = false
-  AI.prefix = nil
-  AI.submit = true
-
-  exec(string.format(
-    "%s %s %s %s",
-    AI_SEND,
-    shell_quote(TRANSCRIPT_FILE),
-    shell_quote(prefix),
-    mode
-  ))
+  exec(
+    string.format(
+      "printf %%s %s | tmux load-buffer -b ai-voice - && tmux paste-buffer -p -d -b ai-voice -t %s && tmux send-keys -t %s Enter",
+      shell_quote(text),
+      shell_quote(AI_TMUX_TARGET),
+      shell_quote(AI_TMUX_TARGET)
+    )
+  )
 
   AI.show()
 end
 
---- Toggle VoxType recording for a tool-specific prompt prefix.
---- Press once to start recording; press again to stop and send/prefill.
+--- @param prefix string
+--- @param submit boolean
+local function start_recording(prefix, submit)
+  ensure_tmux_session()
+
+  local transcript_path = AI_VOICE_DIR
+    .. "/"
+    .. os.date("%Y%m%dT%H%M%S")
+    .. "-"
+    .. tostring(math.random(100000, 999999))
+    .. ".txt"
+  write_session(prefix, submit, transcript_path)
+
+  exec("voxtype record start --file=" .. shell_quote(transcript_path))
+end
+
+local function finish_recording()
+  local session = read_session()
+  clear_session()
+  if not session then return end
+
+  exec(
+    string.format(
+      "%s %s %s %s %s",
+      Scripts.ai_send,
+      shell_quote(session.transcript_path),
+      shell_quote(session.prefix),
+      shell_quote(session.mode),
+      shell_quote(AI_TMUX_TARGET)
+    )
+  )
+
+  AI.show()
+end
+
+--- Safe to call unconditionally, e.g. from the submap's on_exit: stops + sends whatever was recorded, no-op if idle.
+function AI.finish()
+  finish_recording()
+end
+
+--- Discards the in-progress recording instead of sending it.
+function AI.cancel()
+  local session = read_session()
+  if not session then return end
+
+  clear_session()
+  os.remove(session.transcript_path)
+  exec("voxtype record cancel")
+  notify("Recording cancelled")
+end
+
+--- Same key stops/sends; a different key while recording is ignored, not redirected.
 --- @param prefix string
 --- @param submit boolean
 function AI.toggle(prefix, submit)
-  if AI.recording then
+  local session = read_session()
+
+  if session then
+    if session.prefix ~= prefix then
+      notify("Still recording (" .. session.prefix .. ") - press it again to finish, or . to cancel")
+      return
+    end
+
     finish_recording()
+    return
+  end
+
+  local state = voxtype_state()
+  if state ~= "idle" then
+    notify("Voxtype busy (" .. state .. ")")
     return
   end
 

--- a/home/hypr/.config/hypr/lib/actions/ai.lua
+++ b/home/hypr/.config/hypr/lib/actions/ai.lua
@@ -20,6 +20,12 @@ local function shell_quote(value)
   return "'" .. value:gsub("'", "'\\''") .. "'"
 end
 
+--- @param command string
+--- @param rules table|nil
+local function exec(command, rules)
+  hl.dispatch(hl.dsp.exec_cmd(command, rules))
+end
+
 --- @return boolean
 local function window_exists()
   return #hl.get_windows({ class = AI_CLASS }) > 0
@@ -44,7 +50,7 @@ end
 function AI.launch()
   if window_exists() then return end
 
-  hl.exec_cmd(Config.app.term_cmd .. " --class " .. AI_CLASS .. " -e tmuxifier load-session ai", {
+  exec(Config.app.term_cmd .. " --class " .. AI_CLASS .. " -e tmuxifier load-session ai", {
     workspace = "special:" .. AI_WORKSPACE .. " silent",
   })
 end
@@ -73,11 +79,11 @@ local function start_recording(prefix, submit)
   AI.submit = submit
 
   os.remove(TRANSCRIPT_FILE)
-  hl.exec_cmd("voxtype record start --file=" .. shell_quote(TRANSCRIPT_FILE))
+  exec("voxtype record start --file=" .. shell_quote(TRANSCRIPT_FILE))
 end
 
 local function finish_recording()
-  hl.exec_cmd("voxtype record stop")
+  exec("voxtype record stop")
 
   local prefix = AI.prefix or ""
   local mode = AI.submit and "submit" or "prefill"
@@ -86,7 +92,7 @@ local function finish_recording()
   AI.prefix = nil
   AI.submit = true
 
-  hl.exec_cmd(string.format(
+  exec(string.format(
     "%s %s %s %s",
     AI_SEND,
     shell_quote(TRANSCRIPT_FILE),

--- a/home/hypr/.config/hypr/lib/actions/window.lua
+++ b/home/hypr/.config/hypr/lib/actions/window.lua
@@ -18,6 +18,7 @@ local Window = {
 
 local SPECIAL_WS = {
   scratchpad = "special:scratchpad",
+  ai = "special:agents",
 }
 
 --- Focus the monitor in the given slot (1-based index into Config.monitors).

--- a/home/hypr/.config/hypr/lib/scripts.lua
+++ b/home/hypr/.config/hypr/lib/scripts.lua
@@ -9,6 +9,7 @@ local Scripts = {
   -- stylua: ignore start
   screenshot            = HYPR    .. "screenshot.sh",
   voxtype               = HYPR    .. "voxtype-with-media-pause.sh",
+  ai_send               = HYPR    .. "ai-send.sh",
   focus_media_player    = HYPR    .. "focus-media-player.sh",
   nmtui                 = HYPR    .. "nmtui.sh",
   hyprlock              = HYPR    .. "hyprlock-screenshot.lua",

--- a/home/hypr/.config/hypr/scripts/ai-send.sh
+++ b/home/hypr/.config/hypr/scripts/ai-send.sh
@@ -1,52 +1,71 @@
 #!/bin/sh
+# Stops the recording, waits for voxtype to go idle again, pastes the transcript into tmux.
 
 set -eu
 
-if [ "$#" -ne 3 ]; then
-  printf 'usage: %s TRANSCRIPT_FILE PREFIX submit|prefill\n' "$0" >&2
+if [ "$#" -ne 4 ]; then
+  printf 'usage: %s TRANSCRIPT_FILE PREFIX submit|prefill TMUX_TARGET\n' "$0" >&2
   exit 2
 fi
 
 transcript_file="$1"
 prefix="$2"
 mode="$3"
-tmux_target="AI:Claude.0"
+tmux_target="$4"
+
+timeout_seconds=90
+
+notify() {
+  notify-send "AI" "$1" 2>/dev/null || true
+}
+
+fail() {
+  notify "$1"
+  printf '%s\n' "$1" >&2
+  exit 1
+}
 
 case "$mode" in
-  submit|prefill) ;;
-  *)
-    printf 'invalid mode: %s\n' "$mode" >&2
-    exit 2
-    ;;
+  submit | prefill) ;;
+  *) fail "invalid mode: $mode" ;;
 esac
 
-i=0
-previous_size=-1
-stable_count=0
+fifo=$(mktemp -u "${XDG_RUNTIME_DIR:-/tmp}/ai-voice-status.XXXXXX")
+mkfifo "$fifo"
+cleanup() { rm -f "$fifo"; }
+trap cleanup EXIT
 
-while :; do
-  if [ -s "$transcript_file" ]; then
-    current_size=$(wc -c < "$transcript_file")
+timeout "$timeout_seconds" voxtype status --follow --format json >"$fifo" 2>/dev/null &
+watcher_pid=$!
 
-    if [ "$current_size" -eq "$previous_size" ]; then
-      stable_count=$((stable_count + 1))
-      [ "$stable_count" -ge 2 ] && break
-    else
-      previous_size="$current_size"
-      stable_count=0
-    fi
-  fi
+# attach before stop, so first line is "recording" not a stale "idle"
+exec 3<"$fifo"
 
-  i=$((i + 1))
-  [ "$i" -ge 300 ] && exit 1
-  sleep 0.1
+voxtype record stop
+
+found_idle=0
+while IFS= read -r line <&3; do
+  case "$line" in
+    *'"alt": "idle"'*)
+      found_idle=1
+      break
+      ;;
+  esac
 done
 
-transcript=$(cat "$transcript_file")
-[ -n "$transcript" ] || exit 0
+exec 3<&-
+kill "$watcher_pid" 2>/dev/null || true
+wait "$watcher_pid" 2>/dev/null || true
 
-printf '%s %s' "$prefix" "$transcript" | tmux load-buffer -
-tmux paste-buffer -d -t "$tmux_target"
+[ "$found_idle" -eq 1 ] || fail "voxtype transcription timed out"
+
+transcript=$(cat "$transcript_file" 2>/dev/null || true)
+rm -f "$transcript_file"
+
+[ -n "$transcript" ] || { notify "Empty transcript, nothing sent"; exit 0; }
+
+printf '%s %s' "$prefix" "$transcript" | tmux load-buffer -b ai-voice -
+tmux paste-buffer -p -d -b ai-voice -t "$tmux_target"
 
 if [ "$mode" = "submit" ]; then
   tmux send-keys -t "$tmux_target" Enter

--- a/home/hypr/.config/hypr/scripts/ai-send.sh
+++ b/home/hypr/.config/hypr/scripts/ai-send.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 3 ]; then
+  printf 'usage: %s TRANSCRIPT_FILE PREFIX submit|prefill\n' "$0" >&2
+  exit 2
+fi
+
+transcript_file="$1"
+prefix="$2"
+mode="$3"
+tmux_target="AI:Claude.0"
+
+case "$mode" in
+  submit|prefill) ;;
+  *)
+    printf 'invalid mode: %s\n' "$mode" >&2
+    exit 2
+    ;;
+esac
+
+i=0
+while [ ! -s "$transcript_file" ]; do
+  i=$((i + 1))
+  [ "$i" -ge 300 ] && exit 1
+  sleep 0.1
+done
+
+transcript=$(cat "$transcript_file")
+[ -n "$transcript" ] || exit 0
+
+printf '%s %s' "$prefix" "$transcript" | tmux load-buffer -
+tmux paste-buffer -d -t "$tmux_target"
+
+if [ "$mode" = "submit" ]; then
+  tmux send-keys -t "$tmux_target" Enter
+fi

--- a/home/hypr/.config/hypr/scripts/ai-send.sh
+++ b/home/hypr/.config/hypr/scripts/ai-send.sh
@@ -21,7 +21,22 @@ case "$mode" in
 esac
 
 i=0
-while [ ! -s "$transcript_file" ]; do
+previous_size=-1
+stable_count=0
+
+while :; do
+  if [ -s "$transcript_file" ]; then
+    current_size=$(wc -c < "$transcript_file")
+
+    if [ "$current_size" -eq "$previous_size" ]; then
+      stable_count=$((stable_count + 1))
+      [ "$stable_count" -ge 2 ] && break
+    else
+      previous_size="$current_size"
+      stable_count=0
+    fi
+  fi
+
   i=$((i + 1))
   [ "$i" -ge 300 ] && exit 1
   sleep 0.1


### PR DESCRIPTION
Closes #8

## Summary

- creates a dedicated `special:ai` workspace backed by the existing `ai` tmuxifier layout
- launches the AI terminal automatically at Hyprland startup with the typed `hl.dsp.exec_cmd(...)` dispatcher and a workspace launch rule
- adds `Leader + Shift+A` as a persistent global AI submap
- keeps AI orchestration in `lib/actions/ai.lua`
- uses native Hyprland Lua getters/events/dispatchers for window, workspace, and command execution
- keeps the VoxType transcript file as the IPC boundary without touching the clipboard
- moves transcript waiting/prefixing/tmux delivery into the focused `scripts/ai-send.sh` helper
- adds toggle-style VoxType bindings for `gog`, `gh`, `agent-browser`, and shell/system tasks
- first press starts recording; pressing the same tool key again stops/transcribes
- bare tool keys submit to Claude; Ctrl variants prefill without submitting
- keeps the AI submap active after commands; `.` or `Escape` exits it
- targets the stable `AI:Claude.0` tmux pane and pastes through a tmux buffer
- removes the AI tmuxifier launcher from the Work session while leaving the rest of Work unchanged
- lets the workspace summon action relaunch the AI terminal if it has been closed

## Architecture

`keymaps/submaps/ai/init.lua -> lib/actions/ai.lua -> native Hyprland Lua API + voxtype`

`lib/actions/ai.lua -> scripts/ai-send.sh -> transcript file -> tmux -> AI:Claude.0`

Hyprland state stays inside Hyprland: `hl.get_windows()` checks the AI terminal, `hl.get_monitors()` and `active_special_workspace` determine visibility, `hl.on("window.open")` handles first-launch focus without polling, and typed `hl.dsp.workspace.toggle_special()`, `hl.dsp.focus()`, and `hl.dsp.exec_cmd()` dispatchers control compositor actions and external command execution. No `hyprctl` shell dispatch is used.

The shell helper owns only Unix process orchestration: it waits for VoxType to finish writing the runtime transcript, reads and prefixes it, loads it into tmux, pastes it into `AI:Claude.0`, and optionally submits with Enter. The transcript file remains the synchronization/IPC mechanism so the workflow does not overwrite the user's clipboard.

## Bindings

| Key | Action |
| --- | --- |
| `Leader + Shift+A` | Enter AI submap |
| `A` | Show/focus AI workspace |
| `g` / `Ctrl+g` | Toggle `use gog to ...` recording / prefill mode |
| `h` / `Ctrl+h` | Toggle `use gh to ...` recording / prefill mode |
| `b` / `Ctrl+b` | Toggle `use agent-browser to ...` recording / prefill mode |
| `s` / `Ctrl+s` | Toggle shell/system recording / prefill mode |
| `.` / `Escape` | Exit AI submap |

## Notes

The AI session remains defined by `home/tmux/tmuxifier-layouts/ai.session.sh`; this PR reuses its `AI` session and `Claude` window rather than introducing another tmux layout.