### PR TITLE
Add previous-window toggle binding in Hyprland

### DIFF
--- a/home/hypr/.config/hypr/keymaps/global/general.lua
+++ b/home/hypr/.config/hypr/keymaps/global/general.lua
@@ -1,7 +1,6 @@
 local Bind = require("lib.key.bind") ---@class BindLib
 local Config = require("config") ---@class Config
 local Window = require("lib.actions.window") ---@class WindowActions
-local Workspace = require("lib.actions.workspace") ---@class WorkspaceActions
 
 -- stylua: ignore start
 local OPTS = {
@@ -14,7 +13,7 @@ Bind.leader_cmd("SLASH",  require("lib.scripts").keybind_help, OPTS.universal("K
 -- Window Actions
 Bind.leader_key("X",   Window.close(),             "Close Window")
 Bind.leader_key("F",   Window.fullscreen_toggle(), "Toggle Fullscreen")
-Bind.leader_key("TAB", Workspace.focus_last(),     "Go to Last Active WS")
+Bind.leader_key("TAB", Window.focus_last(),        "Previous Window")
 
 -- Window Focus/Movement
 Bind.leader_key({ "H", "LEFT" },  Window.focus_dir("l"), OPTS.universal("Focus Left"))

--- a/home/hypr/.config/hypr/keymaps/global/tools.lua
+++ b/home/hypr/.config/hypr/keymaps/global/tools.lua
@@ -25,6 +25,7 @@ Bind.leader_cmd("CTRL + V", cmd_search_clipboard, "Clipboard History")
 local function select_window(action) return Scripts.window_selector .. " --" .. action end
 Bind.leader_fn("T",                 Menu.hyprwindow(),               "Find window")
 Bind.fn("ALT + TAB",                Menu.hyprwindow(),               "Find window")
+Bind.leader_cmd("TAB",              "hyprctl dispatch focuscurrentorlast", "Previous window")
 Bind.leader_cmd("SHIFT + T",        select_window("move"),           "Move to another window")
 Bind.leader_cmd("CTRL + SHIFT + T", select_window("move-silent"),    "Silent move to another window")
 

--- a/home/hypr/.config/hypr/keymaps/global/tools.lua
+++ b/home/hypr/.config/hypr/keymaps/global/tools.lua
@@ -25,7 +25,6 @@ Bind.leader_cmd("CTRL + V", cmd_search_clipboard, "Clipboard History")
 local function select_window(action) return Scripts.window_selector .. " --" .. action end
 Bind.leader_fn("T",                 Menu.hyprwindow(),               "Find window")
 Bind.fn("ALT + TAB",                Menu.hyprwindow(),               "Find window")
-Bind.leader_cmd("TAB",              "hyprctl dispatch focuscurrentorlast", "Previous window")
 Bind.leader_cmd("SHIFT + T",        select_window("move"),           "Move to another window")
 Bind.leader_cmd("CTRL + SHIFT + T", select_window("move-silent"),    "Silent move to another window")
 

--- a/home/hypr/.config/hypr/lib/actions/window.lua
+++ b/home/hypr/.config/hypr/lib/actions/window.lua
@@ -29,6 +29,9 @@ Window.focus_monitor = function(slot)
   end
 end
 
+--- Focus the previously focused window.
+Window.focus_last = function() return Hypr.dispatch(hl.dsp.focus({ last = true })) end
+
 --- @param dir string  Direction code: "l", "d", "u", "r"
 Window.focus_dir = function(dir) return Hypr.dispatch(hl.dsp.focus({ direction = dir })) end
 


### PR DESCRIPTION
Closes #15.

Adds `Leader+Tab` for Hyprland's `focuscurrentorlast` dispatcher while leaving `Alt+Tab` on the existing full window selector.