### PR TITLE
Restore Yazi packages during automated install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,6 +87,11 @@ main() {
   mapfile -t core < <(read_ini_section stow.ini CORE)
   do_stow "${core[@]}"
 
+  if command -v ya >/dev/null 2>&1 && [[ -f "$HOME/.config/yazi/package.toml" ]]; then
+    info "Installing Yazi packages..."
+    ya pkg install
+  fi
+
   SELECTED_OPTIONAL=()
   prompt_optional
   if [[ ${#SELECTED_OPTIONAL[@]} -gt 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,9 @@ main() {
 
   if command -v ya >/dev/null 2>&1 && [[ -f "$HOME/.config/yazi/package.toml" ]]; then
     info "Installing Yazi packages..."
-    ya pkg install
+    if ! ya pkg install; then
+      warn "Failed to install Yazi packages; continuing"
+    fi
   fi
 
   SELECTED_OPTIONAL=()


### PR DESCRIPTION
Closes #30.

Adds one bootstrap behavior to `install.sh`: after core dotfiles are stowed, run `ya pkg install` when `ya` is available and `~/.config/yazi/package.toml` exists.

This PR intentionally does not change `.gitignore`, package manifest tracking, or plugin source policy. Those concerns are handled separately by #28 / PR #29.