### PR TITLE
feat(hypr): use . for direct AI voice input

### DIFF
--- a/home/hypr/.config/hypr/keymaps/submaps/ai/init.lua
+++ b/home/hypr/.config/hypr/keymaps/submaps/ai/init.lua
@@ -1,7 +1,7 @@
 --- AI command submap
 --- Tool keys toggle VoxType recording on/off.
 --- Bare keys submit the prompt. Ctrl variants prefill without submitting.
---- The submap stays active until `.` or Escape exits it.
+--- Escape exits the submap.
 
 local AI = require("lib.actions.ai") --- @class AI
 local Config = require("config") --- @class Config
@@ -26,7 +26,7 @@ Submap.define({
 
   -- stylua: ignore
   binds = {
-    { "PERIOD",     Submap.reset,                                                  "Exit AI" },
+    { "PERIOD",     function() AI.toggle("", true) end,             "Talk to Agent" },
     { "X",          function() AI.send_text("/clear") end,          "Clear" },
     { "BACKSPACE",  AI.cancel,                                      "Cancel Recording" },
 


### PR DESCRIPTION
## Summary

- change the AI submap `.` binding from exiting the submap to toggling VoxType recording
- send the transcript directly to the active AI agent with no tool prefix
- keep auto-submit behavior consistent with the existing bare tool bindings
- retain Escape as the explicit submap exit

## Behavior

Press `Leader + Shift + A`, then `.` to start recording. Press `.` again to stop, transcribe, paste the prompt into the AI tmux session, and submit it.