### PR TITLE
Fix auto-launcher window placement across monitors/workspaces

### DIFF
--- a/home/hypr/.config/hypr/extensions/auto_launcher/launcher.lua
+++ b/home/hypr/.config/hypr/extensions/auto_launcher/launcher.lua
@@ -37,9 +37,22 @@ local function launch(app, workspace)
   hl.dispatch(hl.dsp.exec_cmd(app.cmd, { workspace = workspace, no_initial_focus = true }))
 end
 
---- Polls for the app's window and applies size/position once it appears.
+--- @return table<string, boolean> set of every currently-open window address
+local function snapshot_addresses()
+  local addrs = {}
+  for _, w in ipairs(hl.get_windows() or {}) do
+    addrs[w.address] = true
+  end
+  return addrs
+end
+
+--- Polls for the app's new window, moves it to the target workspace, and applies size/position.
+--- Backstop for single-instance apps, whose server-owned pid the exec rule can't bind to.
 --- @param app AppEntry
-local function resize_when_ready(app)
+--- @param workspace integer
+--- @param before table<string, boolean> window addresses that existed before this app launched
+--- @param claimed table<string, boolean> addresses already claimed by another poller in this run()
+local function place_when_ready(app, workspace, before, claimed)
   local match_val = app.class or app.title
   if not match_val then return end
   local match_key = app.class and "class" or "title"
@@ -48,9 +61,11 @@ local function resize_when_ready(app)
   t = hl.timer(function()
     attempts = attempts + 1
     for _, w in ipairs(hl.get_windows() or {}) do
-      if w[match_key] == match_val then
+      if w[match_key] == match_val and not before[w.address] and not claimed[w.address] then
+        claimed[w.address] = true
         t:set_enabled(false)
         local window = "address:" .. w.address
+        hl.dispatch(hl.dsp.window.move({ window = window, workspace = workspace, follow = false }))
         if app.size then
           hl.dispatch(hl.dsp.window.resize({
             window = window,
@@ -70,13 +85,15 @@ local function resize_when_ready(app)
         return
       end
     end
-    if attempts >= 30 then t:set_enabled(false) end
-  end, { timeout = 500, type = "repeat" })
+    if attempts >= 60 then t:set_enabled(false) end
+  end, { timeout = 250, type = "repeat" })
 end
 
---- Runs a session: launches each app on its workspace, applying rules and resize as needed.
+--- Runs a session: launches each app on its workspace, applying rules and placement as needed.
 --- @param apps AppEntry[]
 local function run(apps)
+  -- Shared so two same-class launches can't both claim the same window address.
+  local claimed = {}
   for _, app in ipairs(apps) do
     local workspace = ws(assert(app.monitor, "app entry missing monitor index"), app.ws or 1)
     local match_val = app.class or app.title
@@ -84,8 +101,9 @@ local function run(apps)
 
     local function do_launch()
       if match_val then enable_workspace_rule(match_key, match_val, workspace) end
+      local before = snapshot_addresses()
       launch(app, workspace)
-      if (app.size or app.pos) and match_val then resize_when_ready(app) end
+      if match_val then place_when_ready(app, workspace, before, claimed) end
     end
 
     if app.delay then

--- a/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
+++ b/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
@@ -136,7 +136,7 @@ function M.get_sessions()
       { monitor = 3, ws = 1, cmd = "firefox --new-window", class = "firefox" },
       tmuxifier({ session = "uphill" }),
       tmuxifier({ session = "config", ws = 3 }),
-      { monitor = 4, ws = 1, cmd = "slack", class = "Slack", size = { 1064, 461 }, delay = 5000 },
+      { monitor = 4, ws = 1, cmd = "slack", class = "slack", size = { 1064, 461 }, delay = 5000 },
     },
   }
 end

--- a/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
+++ b/home/hypr/.config/hypr/extensions/auto_launcher/sessions.lua
@@ -2,12 +2,14 @@
 -- Workspace app launcher session definitions.
 -- Monitor indices follow Config.monitors order in hyprland.lua:
 
+local Config = require("config") ---@class Config
+
 --- @class AppEntry
 --- @field monitor integer 1-based monitor index
 --- @field ws integer|nil workspace offset within the monitor (default: 1)
 --- @field cmd string shell command to launch
---- @field class string|nil window class for dynamic workspace rule (mutually exclusive with title)
---- @field title string|nil window title for dynamic workspace rule (mutually exclusive with class)
+--- @field class string|nil window class for dynamic workspace rule and window adoption (mutually exclusive with title)
+--- @field title string|nil window title for dynamic workspace rule and window adoption (mutually exclusive with class)
 --- @field size [integer, integer]|nil window size as {w, h} (e.g. {1280, 720})
 --- @field pos [integer, integer]|nil window position as {x, y} (e.g. {100, 200})
 --- @field delay integer|nil milliseconds to wait before launching
@@ -19,10 +21,34 @@ local M = {}
 
 --- @return table<string, AppEntry[]>
 function M.get_sessions()
+  -- Single-instance terminals share one pid, so windows need a per-launch --class to be
+  -- targetable. Must contain the term name for the delete submap's substring match.
+  local term = Config.app.term or "kitty"
+
+  --- @param opts { monitor: integer, ws: integer|nil, exec: string, class_suffix: string, size: [integer, integer]|nil, pos: [integer, integer]|nil, delay: integer|nil }
+  --- @return AppEntry
+  local function term_entry(opts)
+    local class = term .. "-" .. opts.class_suffix
+    return {
+      monitor = opts.monitor,
+      ws = opts.ws,
+      cmd = "term --class " .. class .. " -e " .. opts.exec,
+      class = class,
+      size = opts.size,
+      pos = opts.pos,
+      delay = opts.delay,
+    }
+  end
+
   --- @param opts { session: string, monitor: integer|nil, ws: integer|nil }
   --- @return AppEntry
   local function tmuxifier(opts)
-    return { monitor = opts.monitor or 3, ws = opts.ws or 2, cmd = "term -e tmuxifier load-session " .. opts.session }
+    return term_entry({
+      monitor = opts.monitor or 3,
+      ws = opts.ws or 2,
+      exec = "tmuxifier load-session " .. opts.session,
+      class_suffix = "tmux-" .. opts.session,
+    })
   end
 
   --- @param opts { monitor: integer|nil, ws: integer|nil }|nil
@@ -39,58 +65,75 @@ function M.get_sessions()
 
   return {
     ["🌐 Browsing"] = {
-      { monitor = 3, ws = 1, cmd = "firefox --new-window" },
+      { monitor = 3, ws = 1, cmd = "firefox --new-window", class = "firefox" },
       tmuxifier({ session = "config" }),
     },
 
     ["🧱 Civil"] = {
       betterbird(),
-      { monitor = 3, ws = 1, cmd = "firefox --new-window" },
+      { monitor = 3, ws = 1, cmd = "firefox --new-window", class = "firefox" },
       tmuxifier({ session = "cc-dev" }),
       tmuxifier({ session = "config", ws = 3 }),
-      { monitor = 4, ws = 1, cmd = "slack", class = "Slack", size = { 1064, 461 } },
+      { monitor = 4, ws = 1, cmd = "slack", class = "slack", size = { 1064, 461 } },
     },
 
     ["🛠 Config"] = {
       betterbird(),
-      { monitor = 3, ws = 1, cmd = "firefox --new-window" },
+      { monitor = 3, ws = 1, cmd = "firefox --new-window", class = "firefox" },
       tmuxifier({ session = "config" }),
     },
 
     ["🗂 Files"] = {
-      { monitor = 3, ws = 1, cmd = "thunar" },
-      { monitor = 4, ws = 1, cmd = "term -e yazi" },
+      { monitor = 3, ws = 1, cmd = "thunar", class = "thunar" },
+      term_entry({ monitor = 4, ws = 1, exec = "yazi", class_suffix = "yazi" }),
     },
 
     ["🧩 Game Mods"] = {
-      { monitor = 2, ws = 1, cmd = "steam" },
-      { monitor = 3, ws = 1, cmd = "term -e sh -c 'cd ~/Downloads && exec yazi'" },
-      { monitor = 4, ws = 1, cmd = "term -e sh -c 'cd ~/.steam/steam/steamapps && exec yazi'" },
+      { monitor = 2, ws = 1, cmd = "steam", class = "steam" },
+      term_entry({
+        monitor = 3,
+        ws = 1,
+        exec = "sh -c 'cd ~/Downloads && exec yazi'",
+        class_suffix = "yazi-downloads",
+      }),
+      term_entry({
+        monitor = 4,
+        ws = 1,
+        exec = "sh -c 'cd ~/.steam/steam/steamapps && exec yazi'",
+        class_suffix = "yazi-steamapps",
+      }),
     },
 
     ["🎮 Game"] = {
-      { monitor = 2, ws = 1, cmd = "steam" },
+      { monitor = 2, ws = 1, cmd = "steam", class = "steam" },
     },
 
     ["📅 Meeting"] = {
-      { monitor = 3, ws = 1, cmd = "firefox --new-window" },
-      { monitor = 1, ws = 1, cmd = "firefox --new-window https://calendar.google.com/" },
+      { monitor = 3, ws = 1, cmd = "firefox --new-window", class = "firefox" },
+      -- Delayed so the blank window above is already snapshotted out; both match "firefox".
+      {
+        monitor = 1,
+        ws = 1,
+        cmd = "firefox --new-window https://calendar.google.com/",
+        class = "firefox",
+        delay = 2000,
+      },
     },
 
     ["📊 System Monitor"] = {
-      { monitor = 3, ws = 1, cmd = "term -e journalctl -f" },
-      { monitor = 4, ws = 1, cmd = "term -e btop" },
+      term_entry({ monitor = 3, ws = 1, exec = "journalctl -f", class_suffix = "journalctl" }),
+      term_entry({ monitor = 4, ws = 1, exec = "btop", class_suffix = "btop" }),
     },
 
     ["🛡️ System Update"] = {
-      { monitor = 2, ws = 1, cmd = "term -e topgrade" },
-      { monitor = 3, ws = 1, cmd = "term -e journalctl -f" },
+      term_entry({ monitor = 2, ws = 1, exec = "topgrade", class_suffix = "topgrade" }),
+      term_entry({ monitor = 3, ws = 1, exec = "journalctl -f", class_suffix = "journalctl" }),
     },
 
     ["💼 Work"] = {
       betterbird(),
-      { monitor = 2, ws = 1, cmd = "qutebrowser" },
-      { monitor = 3, ws = 1, cmd = "firefox --new-window" },
+      { monitor = 2, ws = 1, cmd = "qutebrowser", class = "org.qutebrowser.qutebrowser" },
+      { monitor = 3, ws = 1, cmd = "firefox --new-window", class = "firefox" },
       tmuxifier({ session = "uphill" }),
       tmuxifier({ session = "config", ws = 3 }),
       { monitor = 4, ws = 1, cmd = "slack", class = "Slack", size = { 1064, 461 }, delay = 5000 },

--- a/home/hypr/.config/hypr/lib/actions/apps.lua
+++ b/home/hypr/.config/hypr/lib/actions/apps.lua
@@ -20,7 +20,7 @@ Apps.map = {
   hyprconfig  = { program = TERM,          class = "hyprconfig",                    cmd = TERM_CMD .. " --class hyprconfig -e yazi ~/.config/hypr" },
   protonplus  = { program = "protonplus",  class = "protonplus",                    cmd = "protonplus" },
   qutebrowser = { program = "qutebrowser", class = "org.qutebrowser.qutebrowser" },
-  slack       = { program = "slack",       class = "Slack" },
+  slack       = { program = "slack",       class = "slack" },
   steam       = { program = "steam",       class = "steam",                         cmd = "steam"},
   terminal    = { program = TERM,          exclude_title = "Tmux" },
   tmux_ai     = { program = TERM,          title = "Tmux AI",                       cmd = TERM_CMD .. " -e tmuxifier load-session ai" },


### PR DESCRIPTION
## Summary

- snapshot existing Hyprland window addresses before each auto-launcher app starts
- adopt only the newly created matching window for placement and sizing
- prevent concurrent same-class launches from claiming the same window
- explicitly move adopted windows to their configured workspace as a backstop for single-instance/server-owned applications
- give terminal-backed session entries unique classes so they can be targeted deterministically
- add deterministic class metadata and sequencing for ambiguous launches such as Firefox

## Scope

This change is limited to the Hyprland auto-launcher and session definitions. It does not change the underlying physical monitor configuration.

Fixes #47