### PR TITLE
tbkeys: show vim mode and pending count in the status bar

### DIFF
--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -203,6 +203,37 @@
   tk.peek_count = () => (tk.has_count() ? window.count : 1);
   tk.reset_count = () => {
     window.count = undefined;
+    tk.repaint_mode();
+  };
+
+  /**
+   * @returns {Element} the injected mode/count indicator, or null where the mail status bar is absent (e.g. compose windows)
+   */
+  tk.ensure_mode_indicator = () => {
+    const bar = window.document?.getElementById("status-bar");
+    if (!bar) return null;
+    let el = window.document.getElementById("tbkeys-mode-indicator");
+    if (el) return el;
+    el = window.document.createElement("label");
+    el.id = "tbkeys-mode-indicator";
+    el.className = "statusbarpanel";
+    el.style.marginInlineStart = "6px";
+    bar.appendChild(el);
+    return el;
+  };
+
+  // Known gap: the pending chord (e.g. "m" awaiting "r") is not shown - it
+  // lives inside Mousetrap's internal buffer and isn't exposed to us.
+  /**
+   * Repaints the mode/count indicator from window.vim and window.count; a no-op where the status bar is absent.
+   */
+  tk.repaint_mode = () => {
+    const el = tk.ensure_mode_indicator();
+    if (!el) return;
+    const parts = [];
+    if (tk.is_visual()) parts.push("-- VISUAL --");
+    if (tk.has_count()) parts.push(String(window.count));
+    el.textContent = parts.join(" ");
   };
 
   /**
@@ -240,6 +271,7 @@
         : n === 0
           ? window.count
           : n;
+    tk.repaint_mode();
   };
 
   // -- message read-state toggling ----------------------------------------
@@ -430,6 +462,7 @@
       window.vim = "normal";
       window.visualAnchor = undefined;
       window.visualEnd = undefined;
+      tk.repaint_mode();
       return;
     }
     if (typeof tt?.currentIndex !== "number" || tt.currentIndex < 0) return;
@@ -542,12 +575,14 @@
       window.visualAnchor = undefined;
       window.visualEnd = undefined;
     }
+    tk.repaint_mode();
   };
 
   window.tk_escape = () => {
     const was_visual = window.vim === "visual";
     window.vim = "normal";
     window.count = 0;
+    tk.repaint_mode();
     if (was_visual) {
       const tt = tk.get_thread_tree();
       const end =

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -236,7 +236,12 @@
     if (!el) return;
     const parts = [tk.is_visual() ? "-- VISUAL --" : "-- NORMAL --"];
     if (tk.has_count()) parts.push(String(window.count));
-    el.setAttribute("value", parts.join(" "));
+    const text = parts.join(" ");
+    if (el.namespaceURI?.includes("there.is.only.xul")) {
+      el.setAttribute("value", text);
+    } else {
+      el.textContent = text;
+    }
   };
 
   /**
@@ -1058,4 +1063,5 @@
     "tk_mark_unread",
     "tk_mark_flagged",
   ].forEach(tk.record_action);
+  tk.repaint_mode();
 })();

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -210,15 +210,19 @@
    * @returns {Element} the injected mode/count indicator, or null where the mail status bar is absent (e.g. compose windows)
    */
   tk.ensure_mode_indicator = () => {
-    const bar = window.document?.getElementById("status-bar");
-    if (!bar) return null;
-    let el = window.document.getElementById("tbkeys-mode-indicator");
+    const doc = window.document;
+    const host =
+      doc?.getElementById("statusTextBox") ?? doc?.getElementById("status-bar");
+    if (!host) return null;
+    let el = doc.getElementById("tbkeys-mode-indicator");
     if (el) return el;
-    el = window.document.createElement("label");
+    el = doc.createXULElement
+      ? doc.createXULElement("label")
+      : doc.createElement("label");
     el.id = "tbkeys-mode-indicator";
     el.className = "statusbarpanel";
-    el.style.marginInlineStart = "6px";
-    bar.appendChild(el);
+    el.setAttribute("crop", "end");
+    host.insertBefore(el, host.firstChild);
     return el;
   };
 
@@ -233,7 +237,7 @@
     const parts = [];
     if (tk.is_visual()) parts.push("-- VISUAL --");
     if (tk.has_count()) parts.push(String(window.count));
-    el.textContent = parts.join(" ");
+    el.setAttribute("value", parts.join(" "));
   };
 
   /**

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -234,8 +234,7 @@
   tk.repaint_mode = () => {
     const el = tk.ensure_mode_indicator();
     if (!el) return;
-    const parts = [];
-    if (tk.is_visual()) parts.push("-- VISUAL --");
+    const parts = [tk.is_visual() ? "-- VISUAL --" : "-- NORMAL --"];
     if (tk.has_count()) parts.push(String(window.count));
     el.setAttribute("value", parts.join(" "));
   };


### PR DESCRIPTION
First half of PR C in the #65 sequence. Closes #73.

Split from #74 deliberately: the incremental search is specified to reuse this widget for its `projects [2/7]` match counter, so proving the widget in a live window first means #74 builds on something known to work rather than debugging two unverified UI changes at once.

## What lands

Vim mode was invisible state. `window.vim` could be `visual` with nothing on screen saying so, and a pending count was equally silent, so it was easy to be in visual mode without realising and have the next keypress extend a selection instead of moving.

The status bar now names the current mode at all times, `-- NORMAL --` or `-- VISUAL --`, followed by the pending count while it accumulates. Showing the mode in both states rather than only in visual matters for a second reason: a blank indicator would otherwise be ambiguous between normal mode and helpers.js having failed to load, in which case no binding works at all.

## How it hangs off existing state

`window.vim` and `window.count` belong to this keymap, so the indicator repaints from the places that write them rather than polling. Every writer was found by grep rather than assumed, which turned up one the issue did not mention: `tk.run_navigation_command` sets `window.vim = "normal"` when a navigation command crosses folders during visual mode. That path repaints too.

`tk_repeat_last` writes `window.count` directly but is always immediately followed, synchronously, by a wrapped action ending in `tk.reset_count`, which repaints. No separate call is needed there.

`esc` sets `count` to 0 and `has_count()` requires greater than zero, so the indicator correctly shows nothing rather than a literal `0`.

## DOM details

The element mirrors what Thunderbird already does for `unreadMessageCount` and `totalMessageCount` in `messenger.xhtml`: a XUL label with `class="statusbarpanel"` and `crop="end"`, carrying its text in the `value` attribute, inserted at the start of `#statusTextBox` so the mode reads at the left the way vim shows it.

It is a separate element from Thunderbird's own `#statusText`, which the app writes to during folder loads and searches, so the two never clobber each other. Creation is lazy and id-guarded following the `tk.ensure_search_style` pattern, so re-loading `helpers.js` reuses the existing element rather than adding a second. Compose windows have no status bar, so the lookup returns null and every paint is a no-op.

Styling is inherited from `statusbarpanel` rather than hardcoded, so it follows the theme in both light and dark. No colors are set by this change.

## Review

Reviewed by codex, which independently reached the DOM concern I had flagged: `createElement("label")` in Thunderbird's chrome document produces an HTML label rather than the XUL label its siblings are, so the `statusbarpanel` class would not reliably style it, and appending beside the flexing status container could squeeze Thunderbird's own status text. Both are fixed in `7fb5c84` by matching the markup Thunderbird uses for its own status labels and inserting inside the box rather than next to it.

Fallbacks are kept in both directions: `#status-bar` if `#statusTextBox` is missing, and `createElement` where `createXULElement` is unavailable, so a window without the expected chrome degrades to no indicator rather than a thrown error.

## Out of scope

Pending-chord display, for example `m` waiting for `r`. That buffer lives inside tbkeys' Mousetrap instance and is not exposed; mirroring it with our own keydown listener would drift from what tbkeys actually has buffered. Marked in the code as a known gap rather than approximated. Worth revisiting now that a widget exists to hang it on.

## Needs testing in a live window

Whether it renders legibly and in the right place is the whole question here, and it cannot be answered from source. Worth checking: that the indicator reads `-- NORMAL --` at rest, switches to `-- VISUAL --` on `v` and back on `esc`, that typing `3` shows the count and that it clears once consumed, that a folder load writing status text does not disturb it, and that it looks right in your dark theme.

`helpers.js` is stowed, so a new mail window picks it up. `keys.json` is untouched by this change - no pasting needed.

https://claude.ai/code/session_01M4Yh4y48GXFgVzFqzKE9bD

