### PR TITLE
tbkeys: incremental folder search to replace the blocking prompt

### DIFF
--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -201,6 +201,8 @@
    * @returns {number} the pending count prefix, or 1 if none is set
    */
   tk.peek_count = () => (tk.has_count() ? window.count : 1);
+  tk.folder_search_active = false;
+  tk.search_term = "";
   tk.reset_count = () => {
     window.count = undefined;
     tk.repaint_mode();
@@ -236,6 +238,11 @@
     if (!el) return;
     const parts = [tk.is_visual() ? "-- VISUAL --" : "-- NORMAL --"];
     if (tk.has_count()) parts.push(String(window.count));
+    if (tk.folder_search_active) {
+      const matches = window.folderSearchMatches || [];
+      const pos = matches.length ? (window.folderSearchIndex ?? 0) + 1 : 0;
+      parts.push(`/${tk.search_term} [${pos}/${matches.length}]`);
+    }
     const text = parts.join(" ");
     if (el.namespaceURI?.includes("there.is.only.xul")) {
       el.setAttribute("value", text);
@@ -406,6 +413,126 @@
       .forEach((el) =>
         el.classList.remove("tbkeys-search-match", "tbkeys-search-active"),
       );
+  };
+
+  /**
+   * Scans the folder tree's current rows for name matches, highlights them, and selects the first one; used both while typing (tree left expanded) and after accept (tree recollapsed to matches).
+   * @param {Element} ft - the folder tree
+   * @param {string} term - search term, matched case-insensitively
+   * @returns {number[]} row indices that matched
+   */
+  tk.apply_folder_search_highlight = (ft, term) => {
+    const fdoc = ft.ownerDocument;
+    tk.clear_search_highlights(fdoc);
+    const t = term.toLowerCase();
+    const matches = [];
+    if (t) {
+      for (let i = 0; i < ft.rowCount; i++) {
+        const row = ft.getRowAtIndex(i);
+        if (row?.nameLabel?.textContent?.toLowerCase().includes(t))
+          matches.push(i);
+      }
+    }
+    matches.forEach((i) =>
+      ft.getRowAtIndex(i)?.classList.add("tbkeys-search-match"),
+    );
+    window.folderSearchMatches = matches;
+    window.folderSearchIndex = 0;
+    if (matches.length) {
+      ft.getRowAtIndex(matches[0])?.classList.add("tbkeys-search-active");
+      ft.selectedIndex = matches[0];
+      ft.scrollToIndex?.(matches[0]);
+    }
+    return matches;
+  };
+
+  /**
+   * @param {Element} ft - the folder tree
+   * @returns {Element} the incremental-search text input, creating it above the folder tree if absent
+   */
+  tk.ensure_folder_search_input = (ft) => {
+    const fdoc = ft.ownerDocument;
+    let el = fdoc.getElementById("tbkeys-search-input");
+    if (el) return el;
+    el = fdoc.createElement("input");
+    el.id = "tbkeys-search-input";
+    el.type = "text";
+    el.placeholder = "Search folders";
+    el.style.cssText =
+      "display:block; width:100%; box-sizing:border-box; font:inherit; " +
+      "background:#222; color:#fff; border:1px solid #666; padding:2px 4px;";
+    ft.parentElement?.insertBefore(el, ft);
+    return el;
+  };
+
+  /**
+   * @param {Element} ft - the folder tree
+   */
+  tk.close_folder_search_input = (ft) => {
+    ft?.ownerDocument?.getElementById("tbkeys-search-input")?.remove();
+  };
+
+  /**
+   * Re-highlights matches for the term typed so far; the tree stays expanded so row indices don't shift per keystroke.
+   * @param {Element} ft - the folder tree
+   * @param {string} term - search term typed so far
+   */
+  tk.render_folder_search = (ft, term) => {
+    tk.search_term = term.trim();
+    tk.apply_folder_search_highlight(ft, tk.search_term);
+    tk.repaint_mode();
+  };
+
+  /**
+   * Opens the incremental folder search: expands the tree once (no per-keystroke collapse) and focuses a text input above it.
+   */
+  tk.start_folder_search = () => {
+    const ft = tk.get_folder_tree();
+    if (!ft) return;
+    const fdoc = ft.ownerDocument;
+    tk.ensure_search_style(fdoc);
+    tk.clear_search_highlights(fdoc);
+    tk.expand_folder_tree(ft);
+    tk.folder_search_active = true;
+    const input = tk.ensure_folder_search_input(ft);
+    input.value = "";
+    input.oninput = () => tk.render_folder_search(ft, input.value);
+    input.onkeydown = (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        tk.accept_folder_search(ft);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        window.tk_escape();
+      }
+    };
+    input.focus();
+    tk.render_folder_search(ft, "");
+  };
+
+  /**
+   * Accepts the typed term: recollapses the tree to just the matches and their ancestors, leaving highlighting in place for n/N. An empty term cancels instead, via tk_escape.
+   * @param {Element} ft - the folder tree
+   */
+  tk.accept_folder_search = (ft) => {
+    const term = tk.search_term.trim();
+    if (!term) {
+      window.tk_escape();
+      return;
+    }
+    tk.close_folder_search_input(ft);
+    tk.folder_search_active = false;
+    const snapshot = tk.snapshot_folder_rows(ft);
+    const t = term.toLowerCase();
+    const match_idxs = [];
+    snapshot.forEach((r, i) => {
+      if (r.name.toLowerCase().includes(t)) match_idxs.push(i);
+    });
+    const keep = tk.keep_ancestors(snapshot, match_idxs);
+    tk.collapse_folder_tree(ft, (row) => keep.has(row.uri));
+    tk.apply_folder_search_highlight(ft, term);
+    tk.repaint_mode();
+    ft.focus();
   };
 
   /**
@@ -602,15 +729,21 @@
     window.visualAnchor = undefined;
     window.visualEnd = undefined;
     const fdoc = window.gTabmail?.currentAbout3Pane?.document;
-    const had_search = !!(
-      window.folderSearchMatches && window.folderSearchMatches.length
-    );
-    if (fdoc) tk.clear_search_highlights(fdoc);
+    const had_search =
+      tk.folder_search_active ||
+      !!(window.folderSearchMatches && window.folderSearchMatches.length);
+    tk.folder_search_active = false;
+    tk.search_term = "";
+    if (fdoc) {
+      fdoc.getElementById("tbkeys-search-input")?.remove();
+      tk.clear_search_highlights(fdoc);
+    }
     window.folderSearchMatches = undefined;
     window.folderSearchIndex = undefined;
     if (had_search) {
       const ft = tk.get_folder_tree();
       if (ft) {
+        ft.focus();
         const sel_uri = ft.getRowAtIndex(ft.selectedIndex)?.uri;
         const snapshot = tk.snapshot_folder_rows(ft);
         const sel_idx = snapshot.findIndex((r) => r.uri === sel_uri);
@@ -624,6 +757,7 @@
         );
       }
     }
+    tk.repaint_mode();
   };
 
   window.tk_mark_all_read = () => {
@@ -759,37 +893,7 @@
       window.goDoCommand("cmd_toggleQuickFilterBar");
       return;
     }
-    const ft = tk.get_folder_tree();
-    const term = window.prompt("Search folders:");
-    if (!term) return;
-    const t = term.toLowerCase();
-    const fdoc = ft.ownerDocument;
-    tk.ensure_search_style(fdoc);
-    tk.clear_search_highlights(fdoc);
-    tk.expand_folder_tree(ft);
-    const snapshot = tk.snapshot_folder_rows(ft);
-    const match_idxs = [];
-    snapshot.forEach((r, i) => {
-      if (r.name.toLowerCase().includes(t)) match_idxs.push(i);
-    });
-    const keep = tk.keep_ancestors(snapshot, match_idxs);
-    tk.collapse_folder_tree(ft, (row) => keep.has(row.uri));
-    const matches = [];
-    for (let i = 0; i < ft.rowCount; i++) {
-      const row = ft.getRowAtIndex(i);
-      if (row?.nameLabel?.textContent?.toLowerCase().includes(t))
-        matches.push(i);
-    }
-    matches.forEach((i) =>
-      ft.getRowAtIndex(i)?.classList.add("tbkeys-search-match"),
-    );
-    window.folderSearchMatches = matches;
-    window.folderSearchIndex = 0;
-    if (matches.length) {
-      ft.getRowAtIndex(matches[0])?.classList.add("tbkeys-search-active");
-      ft.selectedIndex = matches[0];
-      ft.scrollToIndex?.(matches[0]);
-    }
+    tk.start_folder_search();
   };
 
   window.tk_next_unread_thread = () =>

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -202,6 +202,7 @@
    */
   tk.peek_count = () => (tk.has_count() ? window.count : 1);
   tk.folder_search_active = false;
+  tk.folder_search_origin_uri = null;
   tk.search_term = "";
   tk.reset_count = () => {
     window.count = undefined;
@@ -473,6 +474,20 @@
   };
 
   /**
+   * @param {Element} ft - the folder tree
+   * @param {string} uri - folder URI to select, if a row for it is currently visible
+   */
+  tk.select_folder_row_by_uri = (ft, uri) => {
+    for (let i = 0; i < ft.rowCount; i++) {
+      if (ft.getRowAtIndex(i)?.uri === uri) {
+        ft.selectedIndex = i;
+        ft.scrollToIndex?.(i);
+        return;
+      }
+    }
+  };
+
+  /**
    * Re-highlights matches for the term typed so far; the tree stays expanded so row indices don't shift per keystroke.
    * @param {Element} ft - the folder tree
    * @param {string} term - search term typed so far
@@ -490,6 +505,7 @@
     const ft = tk.get_folder_tree();
     if (!ft) return;
     const fdoc = ft.ownerDocument;
+    tk.folder_search_origin_uri = ft.getRowAtIndex(ft.selectedIndex)?.uri ?? null;
     tk.ensure_search_style(fdoc);
     tk.clear_search_highlights(fdoc);
     tk.expand_folder_tree(ft);
@@ -732,6 +748,9 @@
     const had_search =
       tk.folder_search_active ||
       !!(window.folderSearchMatches && window.folderSearchMatches.length);
+    // True only when escape cancels a still-typing search - accepting one
+    // commits its selection, so a later escape must not second-guess it.
+    const cancelling_active_search = tk.folder_search_active;
     tk.folder_search_active = false;
     tk.search_term = "";
     if (fdoc) {
@@ -744,7 +763,10 @@
       const ft = tk.get_folder_tree();
       if (ft) {
         ft.focus();
-        const sel_uri = ft.getRowAtIndex(ft.selectedIndex)?.uri;
+        const sel_uri =
+          cancelling_active_search && tk.folder_search_origin_uri
+            ? tk.folder_search_origin_uri
+            : ft.getRowAtIndex(ft.selectedIndex)?.uri;
         const snapshot = tk.snapshot_folder_rows(ft);
         const sel_idx = snapshot.findIndex((r) => r.uri === sel_uri);
         const keep = tk.keep_ancestors(
@@ -755,8 +777,11 @@
           ft,
           (row) => keep.has(row.uri) || row.uri === sel_uri,
         );
+        if (cancelling_active_search && sel_idx !== -1)
+          tk.select_folder_row_by_uri(ft, sel_uri);
       }
     }
+    tk.folder_search_origin_uri = null;
     tk.repaint_mode();
   };
 


### PR DESCRIPTION
## Summary
- Replaces the `window.prompt` in `tk_folder_search` with a live text input rendered above the folder tree; matches highlight as you type.
- Tree stays fully expanded while typing (only classList toggles per keystroke, no per-keystroke collapse), deferring the collapse-to-matches step to accept — avoids the perf concern raised in #74.
- Reuses the mode indicator widget (from #73) for term/match position feedback (`/term [i/n]`), and the existing match/keep-ancestor/collapse helpers for search logic — no second search implementation.
- `enter` accepts and leaves highlighting for `n`/`N`; `esc` cancels via `tk_escape`, which restores the tree to its pre-search state.

Closes #74, the last open sub-issue of #65.

## Test plan
- [x] `/` in the folder tree opens an inline input (not a modal prompt)
- [x] Typing narrows and highlights matches live, with no perceptible lag on the full folder list
- [x] Status bar shows `/term [i/n]` while searching
- [x] `enter` accepts, tree recollapses to matches + ancestors, `n`/`N` cycle matches afterwards
- [x] `esc` (during typing or after accept) restores the tree exactly as before search started