### PR TITLE
tbkeys: add ephemeral which-key overlay for pending chords

### DIFF
--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -737,6 +737,62 @@
   tk.whichkey_node = tk.whichkey_trie;
   tk.whichkey_path = [];
   tk.whichkey_timer = null;
+  tk.whichkey_full_shown = false;
+
+  // Group labels for the "?" full command list, shown as "+Label" per
+  // leader key; only leaders that actually have children in the trie above.
+  tk.whichkey_group_labels = {
+    g: "Go",
+    m: "Mark",
+    z: "Scroll/Fold",
+    f: "Filter view",
+    t: "Toggle pane",
+    "[": "Previous",
+    "]": "Next",
+    d: "Delete",
+    M: "Set folder mark",
+    "'": "Jump folder mark",
+  };
+
+  // Single-key (non-chord) bindings shown by "?" alongside the chord
+  // leaders above; kept in sync with keys.json by hand, same as WHICHKEY_ENTRIES.
+  const WHICHKEY_SINGLES = [
+    ["esc", "Cancel / normal mode"],
+    ["h", "Left / back"],
+    ["j", "Down"],
+    ["k", "Up"],
+    ["l", "Right / open"],
+    ["o", "Open message"],
+    ["v", "Toggle visual mode"],
+    ["F", "Forward"],
+    ["r", "Reply"],
+    ["R", "Reply all"],
+    ["x", "Archive"],
+    ["c", "New message"],
+    ["q", "Close message / refresh"],
+    ["u", "Undo"],
+    ["/", "Search"],
+    ["n", "Next search match"],
+    ["N", "Previous search match"],
+    [";", "Open conversation"],
+    ["G", "Go to bottom"],
+    [".", "Repeat last action"],
+    ["0-9", "Count prefix"],
+    ["ctrl+h", "Close message / refresh"],
+    ["ctrl+j", "Next tab"],
+    ["ctrl+k", "Previous tab"],
+    ["ctrl+l", "Open message"],
+    ["ctrl+u", "Page up"],
+    ["ctrl+d", "Page down"],
+    ["ctrl+o", "Jump back"],
+    ["ctrl+i", "Jump forward"],
+    ["ctrl+x", "Close tab/window"],
+    ["ctrl+c", "Close tab/window"],
+    ["alt+h", "Focus thread tree"],
+    ["alt+l", "Focus message pane"],
+    ["shift+h", "Focus folder tree"],
+    ["shift+l", "Focus thread tree"],
+  ];
 
   const WHICHKEY_TEXT_TAGS = new Set([
     "input",
@@ -794,6 +850,24 @@
   };
 
   /**
+   * Shows every chord leader (as "+Label") and every single-key command,
+   * for the "?" full command list.
+   */
+  tk.render_whichkey_full = () => {
+    const el = tk.ensure_whichkey_panel();
+    const lines = ["? -- all commands --"];
+    for (const key of Object.keys(tk.whichkey_trie.children ?? {})) {
+      lines.push(`  ${key}  +${tk.whichkey_group_labels[key] ?? "..."}`);
+    }
+    for (const [key, label] of WHICHKEY_SINGLES) {
+      lines.push(`  ${key}  ${label}`);
+    }
+    el.textContent = lines.join("\n");
+    el.style.display = "block";
+    tk.whichkey_full_shown = true;
+  };
+
+  /**
    * Hides the which-key panel and resets the chord walk back to the trie root.
    */
   tk.hide_whichkey = () => {
@@ -805,6 +879,7 @@
     }
     tk.whichkey_node = tk.whichkey_trie;
     tk.whichkey_path = [];
+    tk.whichkey_full_shown = false;
   };
 
   /**
@@ -820,20 +895,31 @@
       e.metaKey ||
       tk.is_whichkey_text_target(e.target)
     ) {
-      if (tk.whichkey_node !== tk.whichkey_trie) tk.hide_whichkey();
+      if (tk.whichkey_node !== tk.whichkey_trie || tk.whichkey_full_shown)
+        tk.hide_whichkey();
       return;
     }
     if (e.key === "Escape") {
       tk.hide_whichkey();
       return;
     }
+    if (e.key === "?" && tk.whichkey_node === tk.whichkey_trie) {
+      if (tk.whichkey_timer) window.clearTimeout(tk.whichkey_timer);
+      tk.render_whichkey_full();
+      // Longer than a chord's 1000ms - this is a reference list to read, not
+      // a fast-moving prompt.
+      tk.whichkey_timer = window.setTimeout(tk.hide_whichkey, 4000);
+      return;
+    }
     const next = tk.whichkey_node.children?.[e.key];
     if (!next) {
-      if (tk.whichkey_node !== tk.whichkey_trie) tk.hide_whichkey();
+      if (tk.whichkey_node !== tk.whichkey_trie || tk.whichkey_full_shown)
+        tk.hide_whichkey();
       return;
     }
     tk.whichkey_path.push(e.key);
     tk.whichkey_node = next;
+    tk.whichkey_full_shown = false;
     if (tk.whichkey_timer) window.clearTimeout(tk.whichkey_timer);
     if (next.children) {
       tk.render_whichkey(tk.whichkey_path, next.children);
@@ -884,19 +970,6 @@
     window.gTabmail?.currentAbout3Pane?.document
       ?.getElementById("qfb-starred")
       ?.click();
-
-  window.tk_quickmove_goto = () => {
-    const extension = window.ExtensionParent?.GlobalManager?.getExtension?.(
-      "quickmove@mozilla.kewis.ch",
-    );
-    if (!extension) {
-      window.alert(
-        "Quick Folder Move not installed or disabled, check about:addons",
-      );
-      return;
-    }
-    extension.shortcuts?.onCommand?.("goto");
-  };
 
   for (let i = 0; i <= 9; i++) {
     window[`tk_digit_${i}`] = tk.digit(i);

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -903,12 +903,16 @@
       tk.hide_whichkey();
       return;
     }
+    if (tk.whichkey_full_shown) {
+      // Any key dismisses the full list rather than falling through to
+      // chord tracking - it's a reference view, not a chord in progress.
+      tk.hide_whichkey();
+      return;
+    }
     if (e.key === "?" && tk.whichkey_node === tk.whichkey_trie) {
-      if (tk.whichkey_timer) window.clearTimeout(tk.whichkey_timer);
+      // No auto-hide timer - this is a reference list to read, dismissed
+      // only by Esc or the next keypress (handled above).
       tk.render_whichkey_full();
-      // Longer than a chord's 1000ms - this is a reference list to read, not
-      // a fast-moving prompt.
-      tk.whichkey_timer = window.setTimeout(tk.hide_whichkey, 4000);
       return;
     }
     const next = tk.whichkey_node.children?.[e.key];

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -3,6 +3,8 @@
 (function () {
   "use strict";
 
+  window.tk?.whichkey_teardown?.();
+
   const tk = {};
   const PROJECTS_FOLDER = "Projects";
   const MARK_PREF = "tbkeys.folder_marks";
@@ -665,6 +667,198 @@
       tt._selectSingle(found);
     }
   };
+
+  // -- which-key overlay for chord prefixes --------------------------------
+
+  // Explicit sequence -> label table, kept separate from keys.json so labels
+  // stay human-written instead of derived from tk_* function names.
+  const WHICHKEY_ENTRIES = [
+    ["g f", "Focus folder tree"],
+    ["g g", "Go to top"],
+    ["g i", "Go to inbox"],
+    ["g t", "Go to trash"],
+    ["g d", "Go to drafts"],
+    ["g m", "Focus message pane"],
+    ["g s", "Go to sent"],
+    ["g p", "Go to projects"],
+    ["g o", "Find folder"],
+    ["m R", "Mark all read"],
+    ["m r", "Mark read"],
+    ["m u", "Mark unread"],
+    ["m j", "Toggle junk"],
+    ["m s", "Mark starred"],
+    ["m p", "Move to Projects"],
+    ["z M", "Collapse all"],
+    ["z R", "Expand all"],
+    ["z z", "Scroll to center"],
+    ["z t", "Scroll to top"],
+    ["z b", "Scroll to bottom"],
+    ["f u", "View unread"],
+    ["f a", "View all"],
+    ["f s", "Toggle starred filter"],
+    ["t m", "Toggle message pane"],
+    ["t f", "Toggle folder pane"],
+    ["] u", "Next unread thread"],
+    ["[ u", "Previous unread thread"],
+    ["] U", "Next unread (any folder)"],
+    ["[ U", "Previous unread (any folder)"],
+    ["] s", "Next starred"],
+    ["[ s", "Previous starred"],
+    ["] t", "Next thread root"],
+    ["[ t", "Previous thread root"],
+    ["] a", "Next attachment"],
+    ["[ a", "Previous attachment"],
+    ["d d", "Delete"],
+    ...[...MARK_LETTERS].map((l) => [`M ${l}`, `Set folder mark ${l}`]),
+    ...[...MARK_LETTERS].map((l) => [`' ${l}`, `Jump to folder mark ${l}`]),
+  ];
+
+  /**
+   * Builds a prefix trie from sequence/label pairs; each node holds `children`
+   * (keyed by the next key) when it has descendants and `label` when a
+   * sequence ends there. Supports chords of any depth, not just two keys.
+   * @param {[string, string][]} entries - space-joined sequence to label pairs
+   * @returns {Object} trie root node
+   */
+  tk.build_whichkey_trie = (entries) => {
+    const root = {};
+    for (const [seq, label] of entries) {
+      let node = root;
+      for (const key of seq.split(" ")) {
+        node.children ??= {};
+        node.children[key] ??= {};
+        node = node.children[key];
+      }
+      node.label = label;
+    }
+    return root;
+  };
+  tk.whichkey_trie = tk.build_whichkey_trie(WHICHKEY_ENTRIES);
+  tk.whichkey_node = tk.whichkey_trie;
+  tk.whichkey_path = [];
+  tk.whichkey_timer = null;
+
+  const WHICHKEY_TEXT_TAGS = new Set([
+    "input",
+    "textarea",
+    "select",
+    "html:input",
+    "html:textarea",
+    "search-textbox",
+    "xul:search-textbox",
+    "moz-input-search",
+    "browser",
+  ]);
+
+  /**
+   * @param {Element} el - event target to check
+   * @returns {boolean} true if key events there should be left alone (text entry)
+   */
+  tk.is_whichkey_text_target = (el) => {
+    if (!el) return false;
+    if (el.isContentEditable) return true;
+    return WHICHKEY_TEXT_TAGS.has(el.tagName?.toLowerCase?.() ?? "");
+  };
+
+  /**
+   * @returns {Element} the injected which-key panel, creating it if absent
+   */
+  tk.ensure_whichkey_panel = () => {
+    const doc = window.document;
+    let el = doc.getElementById("tbkeys-whichkey");
+    if (el) return el;
+    el = doc.createElement("div");
+    el.id = "tbkeys-whichkey";
+    el.style.cssText =
+      "position:fixed; right:12px; bottom:32px; z-index:2147483647; " +
+      "background:#222; color:#fff; border:1px solid #666; " +
+      "font:12px monospace; padding:6px 10px; white-space:pre; " +
+      "pointer-events:none; display:none;";
+    (doc.body ?? doc.documentElement).appendChild(el);
+    return el;
+  };
+
+  /**
+   * Shows the next valid keys and labels under the current chord prefix.
+   * @param {string[]} path - keys pressed so far in this chord
+   * @param {Object} children - trie children of the current node
+   */
+  tk.render_whichkey = (path, children) => {
+    const el = tk.ensure_whichkey_panel();
+    const lines = [path.join(" ")];
+    for (const [key, node] of Object.entries(children)) {
+      lines.push(`  ${key}  ${node.label ?? "..."}`);
+    }
+    el.textContent = lines.join("\n");
+    el.style.display = "block";
+  };
+
+  /**
+   * Hides the which-key panel and resets the chord walk back to the trie root.
+   */
+  tk.hide_whichkey = () => {
+    const el = window.document.getElementById("tbkeys-whichkey");
+    if (el) el.style.display = "none";
+    if (tk.whichkey_timer) {
+      window.clearTimeout(tk.whichkey_timer);
+      tk.whichkey_timer = null;
+    }
+    tk.whichkey_node = tk.whichkey_trie;
+    tk.whichkey_path = [];
+  };
+
+  /**
+   * Passive capture-phase keydown observer that mirrors chord progress into
+   * the which-key panel without touching default behavior, Mousetrap, or
+   * tbkeys - it only ever reads window.event state it does not own.
+   * @param {KeyboardEvent} e
+   */
+  tk.whichkey_handler = (e) => {
+    if (
+      e.ctrlKey ||
+      e.altKey ||
+      e.metaKey ||
+      tk.is_whichkey_text_target(e.target)
+    ) {
+      if (tk.whichkey_node !== tk.whichkey_trie) tk.hide_whichkey();
+      return;
+    }
+    if (e.key === "Escape") {
+      tk.hide_whichkey();
+      return;
+    }
+    const next = tk.whichkey_node.children?.[e.key];
+    if (!next) {
+      if (tk.whichkey_node !== tk.whichkey_trie) tk.hide_whichkey();
+      return;
+    }
+    tk.whichkey_path.push(e.key);
+    tk.whichkey_node = next;
+    if (tk.whichkey_timer) window.clearTimeout(tk.whichkey_timer);
+    if (next.children) {
+      tk.render_whichkey(tk.whichkey_path, next.children);
+      // Matches Mousetrap's own 1000ms sequence-reset delay so the overlay
+      // never outlives the pending chord it is describing.
+      tk.whichkey_timer = window.setTimeout(tk.hide_whichkey, 1000);
+    } else {
+      tk.hide_whichkey();
+    }
+  };
+
+  window.addEventListener("keydown", tk.whichkey_handler, {
+    capture: true,
+    passive: true,
+  });
+
+  tk.whichkey_teardown = () => {
+    window.removeEventListener("keydown", tk.whichkey_handler, {
+      capture: true,
+    });
+    window.removeEventListener("unload", tk.whichkey_teardown);
+    if (tk.whichkey_timer) window.clearTimeout(tk.whichkey_timer);
+    window.document.getElementById("tbkeys-whichkey")?.remove();
+  };
+  window.addEventListener("unload", tk.whichkey_teardown, { once: true });
 
   window.tk = tk;
 

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -816,6 +816,11 @@
     return WHICHKEY_TEXT_TAGS.has(el.tagName?.toLowerCase?.() ?? "");
   };
 
+  const WHICHKEY_BG = "#141C24";
+  const WHICHKEY_HEADER_COLOR = "#8A93A0";
+  const WHICHKEY_KEY_COLOR = "#D8CF7F";
+  const WHICHKEY_GROUP_COLOR = "#FFA0A0";
+
   /**
    * @returns {Element} the injected which-key panel, creating it if absent
    */
@@ -827,25 +832,49 @@
     el.id = "tbkeys-whichkey";
     el.style.cssText =
       "position:fixed; right:12px; bottom:32px; z-index:2147483647; " +
-      "background:#222; color:#fff; border:1px solid #666; " +
-      "font:12px monospace; padding:6px 10px; white-space:pre; " +
+      `background:${WHICHKEY_BG}; border:1px solid #333; ` +
+      "font:12px monospace; padding:6px 10px; " +
       "pointer-events:none; display:none;";
     (doc.body ?? doc.documentElement).appendChild(el);
     return el;
   };
 
   /**
-   * Shows the next valid keys and labels under the current chord prefix.
+   * @param {Document} doc - owner document to create the row in
+   * @param {string} text - row text
+   * @param {string} color - CSS color for the row
+   * @returns {Element} a single which-key row
+   */
+  tk.whichkey_row = (doc, text, color) => {
+    const row = doc.createElement("div");
+    row.textContent = text;
+    row.style.color = color;
+    return row;
+  };
+
+  /**
+   * Shows the next valid keys and labels under the current chord prefix;
+   * a further chord leader is colored like a "+group" entry, a plain
+   * command like a regular key.
    * @param {string[]} path - keys pressed so far in this chord
    * @param {Object} children - trie children of the current node
    */
   tk.render_whichkey = (path, children) => {
     const el = tk.ensure_whichkey_panel();
-    const lines = [path.join(" ")];
+    const doc = el.ownerDocument;
+    el.textContent = "";
+    el.appendChild(tk.whichkey_row(doc, path.join(" "), WHICHKEY_HEADER_COLOR));
     for (const [key, node] of Object.entries(children)) {
-      lines.push(`  ${key}  ${node.label ?? "..."}`);
+      const is_group = !!node.children;
+      const label = (is_group ? "+" : "") + (node.label ?? "...");
+      el.appendChild(
+        tk.whichkey_row(
+          doc,
+          `  ${key}  ${label}`,
+          is_group ? WHICHKEY_GROUP_COLOR : WHICHKEY_KEY_COLOR,
+        ),
+      );
     }
-    el.textContent = lines.join("\n");
     el.style.display = "block";
   };
 
@@ -855,14 +884,25 @@
    */
   tk.render_whichkey_full = () => {
     const el = tk.ensure_whichkey_panel();
-    const lines = ["? -- all commands --"];
+    const doc = el.ownerDocument;
+    el.textContent = "";
+    el.appendChild(
+      tk.whichkey_row(doc, "? -- all commands --", WHICHKEY_HEADER_COLOR),
+    );
     for (const key of Object.keys(tk.whichkey_trie.children ?? {})) {
-      lines.push(`  ${key}  +${tk.whichkey_group_labels[key] ?? "..."}`);
+      el.appendChild(
+        tk.whichkey_row(
+          doc,
+          `  ${key}  +${tk.whichkey_group_labels[key] ?? "..."}`,
+          WHICHKEY_GROUP_COLOR,
+        ),
+      );
     }
     for (const [key, label] of WHICHKEY_SINGLES) {
-      lines.push(`  ${key}  ${label}`);
+      el.appendChild(
+        tk.whichkey_row(doc, `  ${key}  ${label}`, WHICHKEY_KEY_COLOR),
+      );
     }
-    el.textContent = lines.join("\n");
     el.style.display = "block";
     tk.whichkey_full_shown = true;
   };

--- a/home/thunderbird/.config/tbkeys/helpers.js
+++ b/home/thunderbird/.config/tbkeys/helpers.js
@@ -816,10 +816,11 @@
     return WHICHKEY_TEXT_TAGS.has(el.tagName?.toLowerCase?.() ?? "");
   };
 
-  const WHICHKEY_BG = "#141C24";
+  const WHICHKEY_BG = "#0C0E13";
   const WHICHKEY_HEADER_COLOR = "#8A93A0";
   const WHICHKEY_KEY_COLOR = "#D8CF7F";
   const WHICHKEY_GROUP_COLOR = "#FFA0A0";
+  const WHICHKEY_LABEL_COLOR = "#B0C8DE";
 
   /**
    * @returns {Element} the injected which-key panel, creating it if absent
@@ -843,9 +844,9 @@
    * @param {Document} doc - owner document to create the row in
    * @param {string} text - row text
    * @param {string} color - CSS color for the row
-   * @returns {Element} a single which-key row
+   * @returns {Element} a plain, single-color which-key row
    */
-  tk.whichkey_row = (doc, text, color) => {
+  tk.whichkey_text_row = (doc, text, color) => {
     const row = doc.createElement("div");
     row.textContent = text;
     row.style.color = color;
@@ -853,9 +854,29 @@
   };
 
   /**
+   * @param {Document} doc - owner document to create the row in
+   * @param {string} key - key character(s), always colored WHICHKEY_KEY_COLOR
+   * @param {string} label - description, colored `label_color`
+   * @param {string} label_color - CSS color for the label half
+   * @returns {Element} a which-key row with the key and label colored separately
+   */
+  tk.whichkey_entry_row = (doc, key, label, label_color) => {
+    const row = doc.createElement("div");
+    const key_span = doc.createElement("span");
+    key_span.textContent = `  ${key}  `;
+    key_span.style.color = WHICHKEY_KEY_COLOR;
+    const label_span = doc.createElement("span");
+    label_span.textContent = label;
+    label_span.style.color = label_color;
+    row.appendChild(key_span);
+    row.appendChild(label_span);
+    return row;
+  };
+
+  /**
    * Shows the next valid keys and labels under the current chord prefix;
-   * a further chord leader is colored like a "+group" entry, a plain
-   * command like a regular key.
+   * a further chord leader is labeled like a "+group" entry, a plain
+   * command like a regular label.
    * @param {string[]} path - keys pressed so far in this chord
    * @param {Object} children - trie children of the current node
    */
@@ -863,15 +884,18 @@
     const el = tk.ensure_whichkey_panel();
     const doc = el.ownerDocument;
     el.textContent = "";
-    el.appendChild(tk.whichkey_row(doc, path.join(" "), WHICHKEY_HEADER_COLOR));
+    el.appendChild(
+      tk.whichkey_text_row(doc, path.join(" "), WHICHKEY_HEADER_COLOR),
+    );
     for (const [key, node] of Object.entries(children)) {
       const is_group = !!node.children;
       const label = (is_group ? "+" : "") + (node.label ?? "...");
       el.appendChild(
-        tk.whichkey_row(
+        tk.whichkey_entry_row(
           doc,
-          `  ${key}  ${label}`,
-          is_group ? WHICHKEY_GROUP_COLOR : WHICHKEY_KEY_COLOR,
+          key,
+          label,
+          is_group ? WHICHKEY_GROUP_COLOR : WHICHKEY_LABEL_COLOR,
         ),
       );
     }
@@ -887,20 +911,21 @@
     const doc = el.ownerDocument;
     el.textContent = "";
     el.appendChild(
-      tk.whichkey_row(doc, "? -- all commands --", WHICHKEY_HEADER_COLOR),
+      tk.whichkey_text_row(doc, "? -- all commands --", WHICHKEY_HEADER_COLOR),
     );
     for (const key of Object.keys(tk.whichkey_trie.children ?? {})) {
       el.appendChild(
-        tk.whichkey_row(
+        tk.whichkey_entry_row(
           doc,
-          `  ${key}  +${tk.whichkey_group_labels[key] ?? "..."}`,
+          key,
+          `+${tk.whichkey_group_labels[key] ?? "..."}`,
           WHICHKEY_GROUP_COLOR,
         ),
       );
     }
     for (const [key, label] of WHICHKEY_SINGLES) {
       el.appendChild(
-        tk.whichkey_row(doc, `  ${key}  ${label}`, WHICHKEY_KEY_COLOR),
+        tk.whichkey_entry_row(doc, key, label, WHICHKEY_LABEL_COLOR),
       );
     }
     el.style.display = "block";

--- a/home/thunderbird/tbkeys/keys.json
+++ b/home/thunderbird/tbkeys/keys.json
@@ -68,7 +68,7 @@
   "q": "tbkeys:closeMessageAndRefresh",
   "u": "cmd:cmd_undo",
   "/": "func:tk_folder_search",
-  "?": "func:tk_quickmove_goto",
+  "?": "unset",
   "n": "func:tk_search_next",
   "N": "func:tk_search_prev",
   ";": "cmd:cmd_openConversation",


### PR DESCRIPTION
## Summary

Implements #83: a transient which-key-style overlay for tbkeys chord prefixes (`g`, `m`, `z`, `f`, `t`, `[`, `]`, `M`, `'`), so the next valid keys and their labels show up while a chord is pending, without touching Mousetrap or tbkeys' own dispatch.

## Approach

- A passive, capture-phase `keydown` listener in `helpers.js` mirrors chord progress independently of Mousetrap's internal buffer — never calls `preventDefault`, never runs a command, never reads/writes Mousetrap state.
- Driven by an explicit `WHICHKEY_ENTRIES` sequence-to-label table (hand-written labels, not derived from `tk_*` function names), verified to have 1:1 coverage with every space-containing sequence in `keys.json`.
- Built into a generic prefix trie (`tk.build_whichkey_trie`) so future multi-level chords are supported without new plumbing.
- Overlay hides on chord completion, `Esc`, an invalid key, a 1000ms timeout (matching Mousetrap's own sequence-reset delay), or window unload.
- Skips text-entry targets and modifier-held keydowns entirely, so it never fires during folder search, compose, or ctrl/alt/meta shortcuts.
- `tk.whichkey_teardown()` cleans up the listener, timer, and overlay element (including the old `unload` listener) so re-loading `helpers.js` doesn't leak handlers.

## Verification

- `node --check home/thunderbird/.config/tbkeys/helpers.js` passes.
- `keys.json` still parses; a script cross-check confirmed all 78 space-containing sequences (including `g g`, initially missed) are present in `WHICHKEY_ENTRIES` with no extras.
- Reviewed with codex (`codex exec --sandbox read-only`) in addition to my own pass; findings were a stale-`g g` gap (already caught before the codex pass finished) and a stale-`unload`-listener leak on reload (fixed) — both addressed. A third low-severity note about text-target detection robustness matches the same simple tag-name-check approach already used by tbkeys' own `stopCallback`, so left as-is.
- Not yet exercised in a live Betterbird window — please verify the overlay manually per the issue's acceptance criteria before merging.

Closes #83