### PR TITLE
feat(tbkeys): apply message actions to the whole visual selection

### DIFF
--- a/home/thunderbird/.config/tbkeys/actions.js
+++ b/home/thunderbird/.config/tbkeys/actions.js
@@ -5,16 +5,16 @@
 
   // -- flat tk_* functions for keys.json "func:" bindings ------------------
 
-  // An m chord runs after the leaked m keypress has already flipped read
-  // state, so it undoes that flip first - unless it sets read state itself,
-  // or . is replaying it with no keypress to answer for.
+  // Restores the read state sampled when the chord opened, in case the
+  // leader key still reached Thunderbird's own shortcut; chords that set
+  // read state themselves skip it and just overwrite.
   const m_chord =
-    (apply, compensate = true) =>
+    (apply, restore = true) =>
     () => {
       const tt = tk.get_thread_tree();
       const range = tk.resolve_action_range(tt);
-      if (compensate && !tk.replaying)
-        tk.undo_leaked_read_toggle(tt, range.anchor_hdr);
+      if (restore) tk.restore_read_state();
+      else tk.read_snapshot = null;
       let cursor;
       for (let i = 0; i < range.count; i++) cursor = apply(tt, range);
       if (range.is_visual)
@@ -74,12 +74,7 @@
       return;
     }
     if (!tk.has_count()) window.count = last.count;
-    tk.replaying = true;
-    try {
-      window[last.name]();
-    } finally {
-      tk.replaying = false;
-    }
+    window[last.name]();
   };
 
   [

--- a/home/thunderbird/.config/tbkeys/actions.js
+++ b/home/thunderbird/.config/tbkeys/actions.js
@@ -11,59 +11,64 @@
     tk.toggle_read_state(hdr);
     window.goDoCommand("cmd_markAllRead");
   };
-  window.tk_mark_read = () => {
+  // The read-state nudge is a single-row habit carried over from the original
+  // inline bindings; over a range it would rewrite every selected message.
+  const mark_over_range = (cmd) => () => {
     const tt = tk.get_thread_tree();
-    const hdr = tk.get_current_hdr(tt);
-    tk.toggle_read_state(hdr);
-    const n = tk.peek_count();
-    tk.reset_count();
-    tk.repeat_command("cmd_markAsRead", n);
+    const range = tk.resolve_action_range(tt);
+    if (range.is_visual) {
+      window.goDoCommand(cmd);
+      tk.finish_visual_action(tt, range.cursor_index);
+      return;
+    }
+    tk.toggle_read_state(range.anchor_hdr);
+    tk.repeat_command(cmd, range.count);
   };
-  window.tk_mark_unread = () => {
+
+  const act_over_range = (cmd) => () => {
     const tt = tk.get_thread_tree();
-    const hdr = tk.get_current_hdr(tt);
-    tk.toggle_read_state(hdr);
-    const n = tk.peek_count();
-    tk.reset_count();
-    tk.repeat_command("cmd_markAsUnread", n);
+    const range = tk.resolve_action_range(tt);
+    if (range.is_visual) {
+      window.goDoCommand(cmd);
+      tk.finish_visual_action(tt, range.top_index);
+      return;
+    }
+    tk.repeat_command(cmd, range.count);
   };
-  window.tk_mark_flagged = () => {
-    const tt = tk.get_thread_tree();
-    const hdr = tk.get_current_hdr(tt);
-    tk.toggle_read_state(hdr);
-    const n = tk.peek_count();
-    tk.reset_count();
-    tk.repeat_command("cmd_markAsFlagged", n);
-  };
-  window.tk_delete = () => {
-    const n = tk.peek_count();
-    tk.reset_count();
-    tk.repeat_command("cmd_delete", n);
-  };
-  window.tk_archive = () => {
-    const n = tk.peek_count();
-    tk.reset_count();
-    tk.repeat_command("cmd_archive", n);
-  };
+
+  window.tk_mark_read = mark_over_range("cmd_markAsRead");
+  window.tk_mark_unread = mark_over_range("cmd_markAsUnread");
+  window.tk_mark_flagged = mark_over_range("cmd_markAsFlagged");
+  window.tk_delete = act_over_range("cmd_delete");
+  window.tk_archive = act_over_range("cmd_archive");
+
   window.tk_mark_junk_toggle = () => {
     const tt = tk.get_thread_tree();
-    const hdr = tk.get_current_hdr(tt);
-    if (!hdr) return;
-    const is_junk = hdr.getStringProperty("junkscore") === "100";
-    tk.toggle_read_state(hdr);
+    const range = tk.resolve_action_range(tt);
+    if (!range.anchor_hdr) {
+      if (range.is_visual) tk.finish_visual_action(tt, range.cursor_index);
+      return;
+    }
+    const is_junk = range.anchor_hdr.getStringProperty("junkscore") === "100";
+    if (!range.is_visual) tk.toggle_read_state(range.anchor_hdr);
     window.goDoCommand(is_junk ? "cmd_markAsNotJunk" : "cmd_markAsJunk");
+    if (range.is_visual) tk.finish_visual_action(tt, range.cursor_index);
   };
   window.tk_move_to_projects = () => {
     const tt = tk.get_thread_tree();
     if (!tt) return;
-    const hdr = tk.get_current_hdr(tt);
-    tk.toggle_read_state(hdr);
+    const range = tk.resolve_action_range(tt);
     const folder = tk.find_folder_by_name(tk.PROJECTS_FOLDER);
-    if (!folder) return;
+    if (!folder) {
+      if (range.is_visual) tk.finish_visual_action(tt, range.cursor_index);
+      return;
+    }
+    if (!range.is_visual) tk.toggle_read_state(range.anchor_hdr);
     tt.view?.doCommandWithFolder?.(
       window.Ci.nsMsgViewCommandType.moveMessages,
       folder,
     );
+    if (range.is_visual) tk.finish_visual_action(tt, range.top_index);
   };
 
   window.tk_repeat_last = () => {

--- a/home/thunderbird/.config/tbkeys/actions.js
+++ b/home/thunderbird/.config/tbkeys/actions.js
@@ -5,18 +5,19 @@
 
   // -- flat tk_* functions for keys.json "func:" bindings ------------------
 
-  // Restores the read state sampled when the chord opened, in case the
-  // leader key still reached Thunderbird's own shortcut; chords that set
-  // read state themselves skip it and just overwrite.
+  // Repetition is opt-in: a count only means anything where the acted-on row
+  // leaves the view. Every chord consumes the count either way.
   const m_chord =
-    (apply, restore = true) =>
+    (apply, { restore = true, repeat = false } = {}) =>
     () => {
       const tt = tk.get_thread_tree();
       const range = tk.resolve_action_range(tt);
       if (restore) tk.restore_read_state();
       else tk.read_snapshot = null;
+      const times = repeat ? range.count : 1;
+      tk.effective_count = times;
       let cursor;
-      for (let i = 0; i < range.count; i++) cursor = apply(tt, range);
+      for (let i = 0; i < times; i++) cursor = apply(tt, range);
       if (range.is_visual)
         tk.finish_visual_action(tt, cursor ?? range.cursor_index);
     };
@@ -37,11 +38,14 @@
   );
   window.tk_mark_read = m_chord(
     (tt) => tk.run_view_command(tt, "markMessagesRead"),
-    false,
+    {
+      restore: false,
+      repeat: true,
+    },
   );
   window.tk_mark_unread = m_chord(
     (tt) => tk.run_view_command(tt, "markMessagesUnread"),
-    false,
+    { restore: false, repeat: true },
   );
   window.tk_mark_flagged = m_chord((tt, range) =>
     tk.run_view_command(

--- a/home/thunderbird/.config/tbkeys/actions.js
+++ b/home/thunderbird/.config/tbkeys/actions.js
@@ -5,25 +5,21 @@
 
   // -- flat tk_* functions for keys.json "func:" bindings ------------------
 
-  window.tk_mark_all_read = () => {
-    const tt = tk.get_thread_tree();
-    const hdr = tk.get_current_hdr(tt);
-    tk.toggle_read_state(hdr);
-    window.goDoCommand("cmd_markAllRead");
-  };
-  // The read-state nudge is a single-row habit carried over from the original
-  // inline bindings; over a range it would rewrite every selected message.
-  const mark_over_range = (cmd) => () => {
-    const tt = tk.get_thread_tree();
-    const range = tk.resolve_action_range(tt);
-    if (range.is_visual) {
-      window.goDoCommand(cmd);
-      tk.finish_visual_action(tt, range.cursor_index);
-      return;
-    }
-    tk.toggle_read_state(range.anchor_hdr);
-    tk.repeat_command(cmd, range.count);
-  };
+  // An m chord runs after the leaked m keypress has already flipped read
+  // state, so it undoes that flip first - unless it sets read state itself,
+  // or . is replaying it with no keypress to answer for.
+  const m_chord =
+    (apply, compensate = true) =>
+    () => {
+      const tt = tk.get_thread_tree();
+      const range = tk.resolve_action_range(tt);
+      if (compensate && !tk.replaying)
+        tk.undo_leaked_read_toggle(tt, range.anchor_hdr);
+      let cursor;
+      for (let i = 0; i < range.count; i++) cursor = apply(tt, range);
+      if (range.is_visual)
+        tk.finish_visual_action(tt, cursor ?? range.cursor_index);
+    };
 
   const act_over_range = (cmd) => () => {
     const tt = tk.get_thread_tree();
@@ -36,40 +32,40 @@
     tk.repeat_command(cmd, range.count);
   };
 
-  window.tk_mark_read = mark_over_range("cmd_markAsRead");
-  window.tk_mark_unread = mark_over_range("cmd_markAsUnread");
-  window.tk_mark_flagged = mark_over_range("cmd_markAsFlagged");
-  window.tk_delete = act_over_range("cmd_delete");
-  window.tk_archive = act_over_range("cmd_archive");
-
-  window.tk_mark_junk_toggle = () => {
-    const tt = tk.get_thread_tree();
-    const range = tk.resolve_action_range(tt);
-    if (!range.anchor_hdr) {
-      if (range.is_visual) tk.finish_visual_action(tt, range.cursor_index);
-      return;
-    }
+  window.tk_mark_all_read = m_chord(() =>
+    window.goDoCommand("cmd_markAllRead"),
+  );
+  window.tk_mark_read = m_chord(
+    (tt) => tk.run_view_command(tt, "markMessagesRead"),
+    false,
+  );
+  window.tk_mark_unread = m_chord(
+    (tt) => tk.run_view_command(tt, "markMessagesUnread"),
+    false,
+  );
+  window.tk_mark_flagged = m_chord((tt, range) =>
+    tk.run_view_command(
+      tt,
+      range.anchor_hdr?.isFlagged ? "unflagMessages" : "flagMessages",
+    ),
+  );
+  window.tk_mark_junk_toggle = m_chord((tt, range) => {
+    if (!range.anchor_hdr) return;
     const is_junk = range.anchor_hdr.getStringProperty("junkscore") === "100";
-    if (!range.is_visual) tk.toggle_read_state(range.anchor_hdr);
-    window.goDoCommand(is_junk ? "cmd_markAsNotJunk" : "cmd_markAsJunk");
-    if (range.is_visual) tk.finish_visual_action(tt, range.cursor_index);
-  };
-  window.tk_move_to_projects = () => {
-    const tt = tk.get_thread_tree();
-    if (!tt) return;
-    const range = tk.resolve_action_range(tt);
+    tk.run_view_command(tt, is_junk ? "unjunk" : "junk");
+  });
+  window.tk_move_to_projects = m_chord((tt, range) => {
     const folder = tk.find_folder_by_name(tk.PROJECTS_FOLDER);
-    if (!folder) {
-      if (range.is_visual) tk.finish_visual_action(tt, range.cursor_index);
-      return;
-    }
-    if (!range.is_visual) tk.toggle_read_state(range.anchor_hdr);
-    tt.view?.doCommandWithFolder?.(
+    if (!folder) return;
+    tt?.view?.doCommandWithFolder?.(
       window.Ci.nsMsgViewCommandType.moveMessages,
       folder,
     );
-    if (range.is_visual) tk.finish_visual_action(tt, range.top_index);
-  };
+    return range.top_index;
+  });
+
+  window.tk_delete = act_over_range("cmd_delete");
+  window.tk_archive = act_over_range("cmd_archive");
 
   window.tk_repeat_last = () => {
     const last = tk.last_action;
@@ -78,7 +74,12 @@
       return;
     }
     if (!tk.has_count()) window.count = last.count;
-    window[last.name]();
+    tk.replaying = true;
+    try {
+      window[last.name]();
+    } finally {
+      tk.replaying = false;
+    }
   };
 
   [

--- a/home/thunderbird/.config/tbkeys/core.js
+++ b/home/thunderbird/.config/tbkeys/core.js
@@ -131,17 +131,29 @@
     if (cmd !== undefined) tt?.view?.doCommand?.(cmd);
   };
 
+  tk.read_snapshot = null;
+
   /**
-   * Cancels the read-state flip Thunderbird performs when the bare m keypress leaks past tbkeys, which it does whenever m opens a chord: Mousetrap suppresses the standalone "m" binding while a sequence is pending, so its unset never runs to swallow the key.
-   * @param {Element} tt - the thread tree
-   * @param {Object} hdr - header the flip landed on, or undefined/null to no-op
+   * Records the read state of every selected message as a chord opens. Suppressing the leader key should stop Thunderbird flipping it at all, so this only matters wherever preventDefault fails to reach the native shortcut.
    */
-  tk.undo_leaked_read_toggle = (tt, hdr) => {
-    if (!hdr) return;
-    tk.run_view_command(
-      tt,
-      hdr.isRead ? "markMessagesUnread" : "markMessagesRead",
-    );
+  tk.snapshot_read_state = () => {
+    const hdrs = tk.get_thread_tree()?.view?.getSelectedMsgHdrs?.() ?? [];
+    tk.read_snapshot = hdrs.length
+      ? hdrs.map((hdr) => ({ hdr, is_read: hdr.isRead }))
+      : null;
+  };
+
+  /**
+   * Restores the read state sampled when the chord opened, then clears it. Writes each header back through its own folder rather than issuing one selection-wide command, so a selection that has since changed, or was never uniform, still lands on exactly what was sampled.
+   */
+  tk.restore_read_state = () => {
+    const snapshot = tk.read_snapshot;
+    tk.read_snapshot = null;
+    if (!snapshot) return;
+    for (const { hdr, is_read } of snapshot) {
+      if (hdr.isRead !== is_read)
+        hdr.folder?.markMessagesRead?.([hdr], is_read);
+    }
   };
 
   // -- flat tk_* functions for keys.json "func:" bindings ------------------

--- a/home/thunderbird/.config/tbkeys/core.js
+++ b/home/thunderbird/.config/tbkeys/core.js
@@ -5,6 +5,7 @@
   "use strict";
 
   window.tk?.whichkey_teardown?.();
+  window.tk?.ui_teardown?.();
   window.tk = {};
 })();
 

--- a/home/thunderbird/.config/tbkeys/core.js
+++ b/home/thunderbird/.config/tbkeys/core.js
@@ -86,16 +86,21 @@
   // -- last-action recording for . -----------------------------------------
 
   tk.last_action = null;
+  tk.effective_count = null;
 
   /**
-   * Wraps window[name] so invoking it records itself (and the count it saw) as the last action, for . to replay; delegates to the original with no behavior change.
+   * Wraps window[name] so invoking it records itself as the last action, for . to replay; delegates to the original with no behavior change. Records the count the action actually consumed, which a visual-mode range caps at 1, rather than the count that was merely pending when it started.
    * @param {string} name - name of a window.tk_* function to wrap in place
    */
   tk.record_action = (name) => {
     const original = window[name];
     window[name] = (...args) => {
       tk.last_action = { name, count: tk.peek_count() };
-      return original(...args);
+      tk.effective_count = null;
+      const result = original(...args);
+      if (typeof tk.effective_count === "number")
+        tk.last_action.count = tk.effective_count;
+      return result;
     };
   };
 

--- a/home/thunderbird/.config/tbkeys/core.js
+++ b/home/thunderbird/.config/tbkeys/core.js
@@ -113,7 +113,7 @@
     tk.repaint_mode();
   };
 
-  // -- message read-state toggling ----------------------------------------
+  // -- message state commands ---------------------------------------------
 
   /**
    * @param {Element} tt - the thread tree
@@ -122,11 +122,26 @@
   tk.get_current_hdr = (tt) => tt?.view?.getMsgHdrAt?.(tt.currentIndex);
 
   /**
-   * @param {Object} hdr - message header to toggle, or undefined/null to no-op
+   * Runs an nsMsgViewCommandType command over the view's whole current selection. These name the state to reach rather than toggling, so a command that fires more than once still lands where it was aimed.
+   * @param {Element} tt - the thread tree
+   * @param {string} name - nsMsgViewCommandType member name
    */
-  tk.toggle_read_state = (hdr) => {
-    if (hdr)
-      window.goDoCommand(hdr.isRead ? "cmd_markAsUnread" : "cmd_markAsRead");
+  tk.run_view_command = (tt, name) => {
+    const cmd = window.Ci?.nsMsgViewCommandType?.[name];
+    if (cmd !== undefined) tt?.view?.doCommand?.(cmd);
+  };
+
+  /**
+   * Cancels the read-state flip Thunderbird performs when the bare m keypress leaks past tbkeys, which it does whenever m opens a chord: Mousetrap suppresses the standalone "m" binding while a sequence is pending, so its unset never runs to swallow the key.
+   * @param {Element} tt - the thread tree
+   * @param {Object} hdr - header the flip landed on, or undefined/null to no-op
+   */
+  tk.undo_leaked_read_toggle = (tt, hdr) => {
+    if (!hdr) return;
+    tk.run_view_command(
+      tt,
+      hdr.isRead ? "markMessagesUnread" : "markMessagesRead",
+    );
   };
 
   // -- flat tk_* functions for keys.json "func:" bindings ------------------

--- a/home/thunderbird/.config/tbkeys/selection.js
+++ b/home/thunderbird/.config/tbkeys/selection.js
@@ -13,13 +13,14 @@
   /**
    * Resolves which messages a message action should target: the visual range when active, reasserting the tree selection to match it, or the current row repeated by count otherwise. Consumes any pending count prefix either way.
    * @param {Element} tt - the thread tree
-   * @returns {{is_visual: boolean, count: number, anchor_hdr: Object, top_index: number, cursor_index: number}}
+   * @returns {{is_visual: boolean, count: number, anchor_hdr: (Object|undefined), top_index: (number|undefined), cursor_index: (number|undefined)}} - only is_visual and count are guaranteed; the rest are absent when there is no tree or no row to act on
    */
   tk.resolve_action_range = (tt) => {
     const is_visual = tk.is_visual();
     if (!is_visual) {
       const count = tk.peek_count();
       tk.reset_count();
+      tk.effective_count = count;
       return {
         is_visual,
         count,
@@ -29,6 +30,7 @@
       };
     }
     tk.reset_count();
+    tk.effective_count = 1;
     const last = (tt?.view?.rowCount ?? 0) - 1;
     const raw_anchor =
       typeof window.visualAnchor === "number"

--- a/home/thunderbird/.config/tbkeys/selection.js
+++ b/home/thunderbird/.config/tbkeys/selection.js
@@ -8,6 +8,79 @@
    */
   tk.is_visual = () => window.vim === "visual";
 
+  // -- action target resolution ------------------------------------------
+
+  /**
+   * Resolves which messages a message action should target: the visual range when active, reasserting the tree selection to match it, or the current row repeated by count otherwise. Consumes any pending count prefix either way.
+   * @param {Element} tt - the thread tree
+   * @returns {{is_visual: boolean, count: number, anchor_hdr: Object, top_index: number, cursor_index: number}}
+   */
+  tk.resolve_action_range = (tt) => {
+    const is_visual = tk.is_visual();
+    if (!is_visual) {
+      const count = tk.peek_count();
+      tk.reset_count();
+      return {
+        is_visual,
+        count,
+        anchor_hdr: tk.get_current_hdr(tt),
+        top_index: tt?.currentIndex,
+        cursor_index: tt?.currentIndex,
+      };
+    }
+    tk.reset_count();
+    const last = (tt?.view?.rowCount ?? 0) - 1;
+    const raw_anchor =
+      typeof window.visualAnchor === "number"
+        ? window.visualAnchor
+        : tt?.currentIndex;
+    const raw_end =
+      typeof window.visualEnd === "number"
+        ? window.visualEnd
+        : tt?.currentIndex;
+    // Anchor/end can outlive the rows they named when the view changed under
+    // visual mode, so clamp before handing them to _selectRange.
+    if (
+      !tt ||
+      last < 0 ||
+      typeof raw_anchor !== "number" ||
+      typeof raw_end !== "number"
+    ) {
+      return { is_visual, count: 1 };
+    }
+    const clamp = (i) => Math.min(Math.max(i, 0), last);
+    const anchor = clamp(raw_anchor);
+    const end = clamp(raw_end);
+    tt._selectRange(anchor, end, false);
+    return {
+      is_visual,
+      count: 1,
+      anchor_hdr: tt.view?.getMsgHdrAt?.(anchor),
+      top_index: Math.min(anchor, end),
+      cursor_index: end,
+    };
+  };
+
+  /**
+   * Exits visual mode and collapses the tree selection to a single row after an action ran over a range.
+   * @param {Element} tt - the thread tree
+   * @param {number} cursor_index - row to select, clamped to the surviving row count
+   */
+  tk.finish_visual_action = (tt, cursor_index) => {
+    window.vim = "normal";
+    window.visualAnchor = undefined;
+    window.visualEnd = undefined;
+    const last = (tt?.view?.rowCount ?? 0) - 1;
+    if (tt && last >= 0) {
+      const target =
+        typeof cursor_index === "number" && cursor_index >= 0
+          ? cursor_index
+          : last;
+      tt._selectSingle(Math.min(target, last));
+    }
+    tk.repaint_mode();
+  };
+
   // -- flat tk_* functions for keys.json "func:" bindings ------------------
 
   window.tk_toggle_visual = () => {

--- a/home/thunderbird/.config/tbkeys/ui.js
+++ b/home/thunderbird/.config/tbkeys/ui.js
@@ -9,6 +9,8 @@
     insert: "-- INSERT --",
   };
 
+  const QUICK_FILTER_ID = "qfb-qs-textbox";
+
   /**
    * @returns {Element} the injected mode/count indicator, or null where the mail status bar is absent (e.g. compose windows)
    */
@@ -88,11 +90,40 @@
       ? window.setTimeout(tk.sync_insert_mode, 0)
       : tk.sync_insert_mode();
 
+  /**
+   * @param {Element} el - element to check
+   * @returns {boolean} true if the element or an ancestor is the quick filter input
+   */
+  tk.is_quick_filter = (el) => {
+    for (let node = el; node; node = node.parentElement) {
+      if (node.id === QUICK_FILTER_ID) return true;
+    }
+    return false;
+  };
+
+  /**
+   * Sends focus to the thread tree when Enter is pressed in the quick filter, which filters as you type and has nothing left to submit.
+   * @param {KeyboardEvent} e
+   */
+  tk.quick_filter_enter_handler = (e) => {
+    if (e.key !== "Enter" || e.ctrlKey || e.altKey || e.metaKey) return;
+    if (!tk.is_quick_filter(e.target)) return;
+    e.preventDefault();
+    window.tk_focus_thread_tree?.();
+    tk.sync_insert_mode();
+  };
+
   window.addEventListener("focusin", tk.focus_handler, { capture: true });
   window.addEventListener("focusout", tk.focus_handler, { capture: true });
+  window.addEventListener("keydown", tk.quick_filter_enter_handler, {
+    capture: true,
+  });
 
   tk.ui_teardown = () => {
     window.removeEventListener("focusin", tk.focus_handler, { capture: true });
     window.removeEventListener("focusout", tk.focus_handler, { capture: true });
+    window.removeEventListener("keydown", tk.quick_filter_enter_handler, {
+      capture: true,
+    });
   };
 })(window.tk);

--- a/home/thunderbird/.config/tbkeys/ui.js
+++ b/home/thunderbird/.config/tbkeys/ui.js
@@ -1,6 +1,13 @@
-// Persistent mode/count/status indicator in the mail window's status bar.
+// Persistent mode/count/status indicator in the mail window's status bar,
+// and the insert-mode tracking that follows focus in and out of text fields.
 (function (tk) {
   "use strict";
+
+  const MODE_LABELS = {
+    normal: "-- NORMAL --",
+    visual: "-- VISUAL --",
+    insert: "-- INSERT --",
+  };
 
   /**
    * @returns {Element} the injected mode/count indicator, or null where the mail status bar is absent (e.g. compose windows)
@@ -30,7 +37,7 @@
   tk.repaint_mode = () => {
     const el = tk.ensure_mode_indicator();
     if (!el) return;
-    const parts = [tk.is_visual() ? "-- VISUAL --" : "-- NORMAL --"];
+    const parts = [MODE_LABELS[window.vim] ?? MODE_LABELS.normal];
     if (tk.has_count()) parts.push(String(window.count));
     if (tk.folder_search_active) {
       const matches = window.folderSearchMatches || [];
@@ -43,5 +50,49 @@
     } else {
       el.textContent = text;
     }
+  };
+
+  // -- insert mode ----------------------------------------------------------
+
+  tk.mode_before_insert = null;
+
+  /**
+   * @returns {boolean} true when focus sits in a field that takes typed text, in either the chrome window or the 3-pane document
+   */
+  tk.is_text_focus = () =>
+    !!(
+      tk.is_text_input?.(window.document?.activeElement) ||
+      tk.is_text_input?.(tk.get_inbox_doc()?.activeElement)
+    );
+
+  /**
+   * Enters insert mode while a text field holds focus and returns to the mode that was current before it, so a visual selection survives a trip through the filter box.
+   */
+  tk.sync_insert_mode = () => {
+    const in_text = tk.is_text_focus();
+    if (in_text) {
+      if (window.vim === "insert") return;
+      tk.mode_before_insert = window.vim ?? "normal";
+      window.vim = "insert";
+    } else {
+      if (window.vim !== "insert") return;
+      window.vim = tk.mode_before_insert ?? "normal";
+      tk.mode_before_insert = null;
+    }
+    tk.repaint_mode();
+  };
+
+  // focusout fires before activeElement moves, so recheck on the next tick.
+  tk.focus_handler = (e) =>
+    e.type === "focusout"
+      ? window.setTimeout(tk.sync_insert_mode, 0)
+      : tk.sync_insert_mode();
+
+  window.addEventListener("focusin", tk.focus_handler, { capture: true });
+  window.addEventListener("focusout", tk.focus_handler, { capture: true });
+
+  tk.ui_teardown = () => {
+    window.removeEventListener("focusin", tk.focus_handler, { capture: true });
+    window.removeEventListener("focusout", tk.focus_handler, { capture: true });
   };
 })(window.tk);

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -347,11 +347,8 @@
     tk.whichkey_full_shown = false;
     if (tk.whichkey_timer) window.clearTimeout(tk.whichkey_timer);
     if (next.children) {
-      // Mousetrap holds back a standalone binding while that key is the
-      // prefix of a pending sequence, so keys.json's "unset" never runs and
-      // the leader reaches Thunderbird's own shortcut. Cancel it on the
-      // keypress rather than here: keydown cancels the keypress outright,
-      // and Mousetrap matches plain-character sequences on keypress.
+      // Cancelling on keydown would take the keypress with it, and Mousetrap
+      // needs that keypress to start a plain-character sequence.
       if (tk.is_mail_window()) {
         tk.suppress_keypress = true;
         tk.snapshot_read_state();

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -375,7 +375,10 @@
       // needs that keypress to start a plain-character sequence.
       if (tk.is_mail_window()) {
         tk.suppress_keypress = e.key;
-        tk.snapshot_read_state();
+        // m is the only leader whose native shortcut writes read state, and
+        // only an m chord ever restores, so a wider sample could only go stale.
+        if (tk.whichkey_path.length === 1 && e.key === "m")
+          tk.snapshot_read_state();
       }
       tk.render_whichkey(tk.whichkey_path, next.children);
       // Matches Mousetrap's own 1000ms sequence-reset delay so the overlay

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -147,17 +147,33 @@
     "moz-input-search",
     "account-hub-container",
     "imconversation",
-    "browser",
   ]);
 
+  // Held apart from the text tags: a browser is opaque to us rather than a
+  // text field, and everything in the 3-pane sits inside one.
+  const WHICHKEY_OPAQUE_TAGS = new Set(["browser"]);
+
   /**
-   * @param {Element} el - event target to check
-   * @returns {boolean} true if key events there should be left alone (text entry)
+   * @param {Element} el - element to check
+   * @returns {boolean} true if the element or an ancestor takes typed text
    */
-  tk.is_whichkey_text_target = (el) => {
+  tk.is_text_input = (el) => {
     for (let node = el; node; node = node.parentElement) {
       if (node.isContentEditable) return true;
       if (WHICHKEY_TEXT_TAGS.has(node.tagName?.toLowerCase?.() ?? ""))
+        return true;
+    }
+    return false;
+  };
+
+  /**
+   * @param {Element} el - event target to check
+   * @returns {boolean} true if key events there should be left alone
+   */
+  tk.is_whichkey_text_target = (el) => {
+    if (tk.is_text_input(el)) return true;
+    for (let node = el; node; node = node.parentElement) {
+      if (WHICHKEY_OPAQUE_TAGS.has(node.tagName?.toLowerCase?.() ?? ""))
         return true;
     }
     return false;
@@ -317,6 +333,7 @@
    * @param {KeyboardEvent} e
    */
   tk.whichkey_handler = (e) => {
+    tk.sync_insert_mode?.();
     if (
       e.ctrlKey ||
       e.altKey ||

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -74,7 +74,7 @@
   tk.whichkey_path = [];
   tk.whichkey_timer = null;
   tk.whichkey_full_shown = false;
-  tk.suppress_keypress = false;
+  tk.suppress_keypress = null;
 
   // Group labels for the "?" full command list, shown as "+Label" per
   // leader key; only leaders that actually have children in the trie above.
@@ -131,15 +131,22 @@
     ["shift+l", "Focus thread tree"],
   ];
 
+  // Mirrors the tag list in tbkeys' own stopCallback: several of these are
+  // custom elements whose shadow DOM retargets events to the host.
   const WHICHKEY_TEXT_TAGS = new Set([
     "input",
     "textarea",
     "select",
+    "textbox",
     "html:input",
     "html:textarea",
+    "search-bar",
     "search-textbox",
     "xul:search-textbox",
+    "global-search-bar",
     "moz-input-search",
+    "account-hub-container",
+    "imconversation",
     "browser",
   ]);
 
@@ -299,7 +306,7 @@
    */
   tk.abort_chord = () => {
     tk.read_snapshot = null;
-    tk.suppress_keypress = false;
+    tk.suppress_keypress = null;
     tk.hide_whichkey();
   };
 
@@ -350,7 +357,7 @@
       // Cancelling on keydown would take the keypress with it, and Mousetrap
       // needs that keypress to start a plain-character sequence.
       if (tk.is_mail_window()) {
-        tk.suppress_keypress = true;
+        tk.suppress_keypress = e.key;
         tk.snapshot_read_state();
       }
       tk.render_whichkey(tk.whichkey_path, next.children);
@@ -367,8 +374,10 @@
    * @param {KeyboardEvent} e
    */
   tk.whichkey_keypress_handler = (e) => {
-    if (!tk.suppress_keypress) return;
-    tk.suppress_keypress = false;
+    const key = tk.suppress_keypress;
+    tk.suppress_keypress = null;
+    if (key !== e.key || e.ctrlKey || e.altKey || e.metaKey) return;
+    if (tk.is_whichkey_text_target(e.target)) return;
     e.preventDefault();
   };
 

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -1,7 +1,8 @@
-// Passive which-key overlay for pending chord prefixes: chord trie/metadata,
-// delay/timer state, and transient rendering. Visualization only - never
-// touches Mousetrap or tbkeys keyboard dispatch. Loaded last, so it also
-// fires the initial repaint once every module has populated window.tk.
+// Which-key overlay for pending chord prefixes: chord trie/metadata, delay/
+// timer state, and transient rendering. Never touches Mousetrap or tbkeys
+// dispatch; its one non-passive act is suppressing a chord leader's native
+// Thunderbird shortcut, which tbkeys itself cannot swallow. Loaded last, so
+// it also fires the initial repaint once every module has populated window.tk.
 (function (tk) {
   "use strict";
 
@@ -146,10 +147,20 @@
    * @returns {boolean} true if key events there should be left alone (text entry)
    */
   tk.is_whichkey_text_target = (el) => {
-    if (!el) return false;
-    if (el.isContentEditable) return true;
-    return WHICHKEY_TEXT_TAGS.has(el.tagName?.toLowerCase?.() ?? "");
+    for (let node = el; node; node = node.parentElement) {
+      if (node.isContentEditable) return true;
+      if (WHICHKEY_TEXT_TAGS.has(node.tagName?.toLowerCase?.() ?? ""))
+        return true;
+    }
+    return false;
   };
+
+  /**
+   * @returns {boolean} true in the 3-pane mail window, false in compose windows
+   */
+  tk.is_mail_window = () =>
+    window.document?.documentElement?.getAttribute("windowtype") ===
+    "mail:3pane";
 
   const WHICHKEY_BG = "#0C0E13";
   const WHICHKEY_HEADER_COLOR = "#8A93A0";
@@ -283,9 +294,17 @@
   };
 
   /**
-   * Passive capture-phase keydown observer that mirrors chord progress into
-   * the which-key panel without touching default behavior, Mousetrap, or
-   * tbkeys - it only ever reads window.event state it does not own.
+   * Abandons a chord without running one: drops the read-state sample too, so a later chord cannot consume it. Completing a chord goes through hide_whichkey instead, leaving the sample for the action to restore from.
+   */
+  tk.abort_chord = () => {
+    tk.read_snapshot = null;
+    tk.hide_whichkey();
+  };
+
+  /**
+   * Capture-phase keydown observer that mirrors chord progress into the
+   * which-key panel and suppresses a chord leader's native Thunderbird
+   * shortcut. Never touches Mousetrap or tbkeys state it does not own.
    * @param {KeyboardEvent} e
    */
   tk.whichkey_handler = (e) => {
@@ -296,17 +315,17 @@
       tk.is_whichkey_text_target(e.target)
     ) {
       if (tk.whichkey_node !== tk.whichkey_trie || tk.whichkey_full_shown)
-        tk.hide_whichkey();
+        tk.abort_chord();
       return;
     }
     if (e.key === "Escape") {
-      tk.hide_whichkey();
+      tk.abort_chord();
       return;
     }
     if (tk.whichkey_full_shown) {
       // Any key dismisses the full list rather than falling through to
       // chord tracking - it's a reference view, not a chord in progress.
-      tk.hide_whichkey();
+      tk.abort_chord();
       return;
     }
     if (e.key === "?" && tk.whichkey_node === tk.whichkey_trie) {
@@ -318,7 +337,7 @@
     const next = tk.whichkey_node.children?.[e.key];
     if (!next) {
       if (tk.whichkey_node !== tk.whichkey_trie || tk.whichkey_full_shown)
-        tk.hide_whichkey();
+        tk.abort_chord();
       return;
     }
     tk.whichkey_path.push(e.key);
@@ -326,19 +345,23 @@
     tk.whichkey_full_shown = false;
     if (tk.whichkey_timer) window.clearTimeout(tk.whichkey_timer);
     if (next.children) {
+      // Mousetrap holds back a standalone binding while that key is the
+      // prefix of a pending sequence, so keys.json's "unset" never runs and
+      // the leader reaches Thunderbird's own shortcut. Swallow it here.
+      if (tk.is_mail_window()) {
+        e.preventDefault();
+        tk.snapshot_read_state();
+      }
       tk.render_whichkey(tk.whichkey_path, next.children);
       // Matches Mousetrap's own 1000ms sequence-reset delay so the overlay
       // never outlives the pending chord it is describing.
-      tk.whichkey_timer = window.setTimeout(tk.hide_whichkey, 1000);
+      tk.whichkey_timer = window.setTimeout(tk.abort_chord, 1000);
     } else {
       tk.hide_whichkey();
     }
   };
 
-  window.addEventListener("keydown", tk.whichkey_handler, {
-    capture: true,
-    passive: true,
-  });
+  window.addEventListener("keydown", tk.whichkey_handler, { capture: true });
 
   tk.whichkey_teardown = () => {
     window.removeEventListener("keydown", tk.whichkey_handler, {

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -74,6 +74,7 @@
   tk.whichkey_path = [];
   tk.whichkey_timer = null;
   tk.whichkey_full_shown = false;
+  tk.suppress_keypress = false;
 
   // Group labels for the "?" full command list, shown as "+Label" per
   // leader key; only leaders that actually have children in the trie above.
@@ -298,6 +299,7 @@
    */
   tk.abort_chord = () => {
     tk.read_snapshot = null;
+    tk.suppress_keypress = false;
     tk.hide_whichkey();
   };
 
@@ -347,9 +349,11 @@
     if (next.children) {
       // Mousetrap holds back a standalone binding while that key is the
       // prefix of a pending sequence, so keys.json's "unset" never runs and
-      // the leader reaches Thunderbird's own shortcut. Swallow it here.
+      // the leader reaches Thunderbird's own shortcut. Cancel it on the
+      // keypress rather than here: keydown cancels the keypress outright,
+      // and Mousetrap matches plain-character sequences on keypress.
       if (tk.is_mail_window()) {
-        e.preventDefault();
+        tk.suppress_keypress = true;
         tk.snapshot_read_state();
       }
       tk.render_whichkey(tk.whichkey_path, next.children);
@@ -361,10 +365,26 @@
     }
   };
 
+  /**
+   * Cancels the native shortcut for a leader key that whichkey_handler has just seen open a chord. Runs on keypress so the event still reaches Mousetrap, which preventDefault does not block and which needs the keypress to start a plain-character sequence.
+   * @param {KeyboardEvent} e
+   */
+  tk.whichkey_keypress_handler = (e) => {
+    if (!tk.suppress_keypress) return;
+    tk.suppress_keypress = false;
+    e.preventDefault();
+  };
+
   window.addEventListener("keydown", tk.whichkey_handler, { capture: true });
+  window.addEventListener("keypress", tk.whichkey_keypress_handler, {
+    capture: true,
+  });
 
   tk.whichkey_teardown = () => {
     window.removeEventListener("keydown", tk.whichkey_handler, {
+      capture: true,
+    });
+    window.removeEventListener("keypress", tk.whichkey_keypress_handler, {
       capture: true,
     });
     window.removeEventListener("unload", tk.whichkey_teardown);


### PR DESCRIPTION
Closes #87. Part of #65.

## What was wrong

Visual mode selected rows but no action respected the selection. `v j j x` archived one message, not three. Every mutation in `actions.js` resolved its target through `tk.get_current_hdr(tt)` - the single header at `threadTree.currentIndex` - then repeated `goDoCommand` once per count prefix, so the count rather than the selected range decided how many messages were affected.

## What changed

`selection.js` gains two helpers:

- `tk.resolve_action_range(tt)` answers "which messages does this action apply to" once, for every action. Normal mode returns the current row plus the pending count, unchanged from before. Visual mode reasserts the tree selection from `visualAnchor`/`visualEnd` so the view selection provably matches the intended range, and reports a count of 1 so a stray count cannot multiply with the range. Anchor and end are clamped to the current row count first, since they can outlive the rows they named when the view changes under visual mode and `_selectRange` does no bounds checking.
- `tk.finish_visual_action(tt, cursor_index)` exits visual mode and collapses the selection back to a single row.

`actions.js` then dispatches one command against that selection instead of iterating headers - Thunderbird's own range-capable path, the same pattern `tk_move_to_projects` already used via `doCommandWithFolder`. Cursor placement after the action is the top of the range for delete, archive and move, since that row takes the range's place, and the cursor row for the state-changing marks.

`keys.json` is untouched and no key binding changed. Normal-mode behavior, counts included, is unchanged.

## Notable decisions

**The read-state nudge stays out of the visual path.** `tk.toggle_read_state` is a single-row habit inherited from the original inline `keys.json` bindings. Running it against a multi-row selection would rewrite the read state of every selected message as a side effect of flagging or moving them, so the visual branch skips it. Normal mode keeps it exactly as-is.

**Cursor placement does not read `currentIndex` back after the command.** That value can be stale, or `-1` when the command removes the trailing rows. Using the pre-action top of the range is deterministic.

**Junk direction is decided from the anchor header alone**, so a mixed selection toggles one way rather than splitting.

**Early returns now exit visual mode.** A missing header in the junk toggle, or a missing Projects folder in the move, used to leave visual mode active with the multi-row selection stranded.

**One small normal-mode divergence:** `tk_mark_junk_toggle` and `tk_move_to_projects` never read or reset the count prefix before this change, so a stray count typed before them leaked into the next command. Routing them through the shared resolver clears it. Neither action was ever count-repeatable, so the only change is that the leak is gone.

## Review

Implemented by a Sonnet subagent, then reviewed by me and independently by `codex exec`. Six findings between the two reviews; five were applied (read-state amplification over a range, both stranded early returns, unclamped `_selectRange` indices, and post-command `currentIndex` being unsafe for cursor placement). The sixth - that the junk toggle's normal-mode no-header path now resets a pending count - was judged correct as written and is documented above.

## Verification

`node --check` passes on all nine modules, `prettier --check` is clean, and `keys.json` still parses.

Everything else needs a live mail window, since this code only runs inside Betterbird. `selection.js` and `actions.js` are stowed to `~/.config/tbkeys/`, so opening a new mail window picks up the change - no restart needed, `betterbird.cfg` is untouched.

Worth checking:

- `v j j` then each of `x`, `d d`, `m p`, `m r`, `m u`, `m s`, `m j` - all selected messages should be affected, exactly once.
- A selection extended upward with `k` behaves the same as one extended downward with `j`.
- After each action, visual mode is off and the cursor sits on a sensible row - particularly after deleting or archiving the last rows in a folder.
- Selecting to the first or last row and acting there touches nothing outside the selection.
- Normal-mode spot check: `3 x`, `3 d d`, `5 m r` still repeat as before, and `m s` still behaves as it did.
- The whole design rests on `goDoCommand` acting on the tree's multi-row selection rather than just `currentIndex`. That is the documented `nsMsgViewCommandType` behavior but is the one assumption I could not verify without running it.


---

## Follow-up: the leaked `m` keypress (second commit)

Testing surfaced two bugs that share a root cause, and one of them was mine.

tbkeys dispatches chords through Mousetrap, whose callback returns `false` so bound keys get `preventDefault`. But Mousetrap suppresses a standalone binding while that key is the prefix of a pending sequence, so the `"m": "unset"` entry never runs when `m` opens a chord. Nothing prevents the default, the keypress reaches Thunderbird, and native `m` toggles read state before our chord callback runs.

**`tk.toggle_read_state` was the compensator for that**, not the stray single-row habit the first commit took it for. Dropping it from the visual path left every visual-mode `m` chord flipping the read state of the whole selection. It returns as `tk.undo_leaked_read_toggle`, named for what it does, and now covers visual ranges as well as single rows.

**The state commands were toggles.** `cmd_markAsFlagged`, `cmd_markAsJunk` and `cmd_markAsRead` flip rather than set, so any spurious extra dispatch undoes the intended change - a star observed going on, off, then on again. The mark chords now use `nsMsgViewCommandType` commands that name the target state (`flagMessages`/`unflagMessages`, `junk`/`unjunk`, `markMessagesRead`/`markMessagesUnread`), with direction decided once from the anchor header, so firing twice lands on the same state. Those commands act on the view's whole selection too, which is what the visual-mode work needed anyway.

Two chords opt out of the compensation: `m r` and `m u` set read state explicitly, so compensating first is a wasted write, and a `tk.replaying` guard stops `.` from compensating for an `m` press that never happened.

### Review of the follow-up

Codex found two issues in this commit, both valid and both fixed:

- `junkMessages`/`unjunkMessages` are not `nsMsgViewCommandType` members - the real names are `junk`/`unjunk`. `run_view_command` guards on `undefined`, so junk toggling would have silently done nothing. Names are now verified against `nsMsgViewCommandType` usage in Betterbird's own `omni.ja`.
- Dropping count repetition from the mark chords did lose real behavior. I had reasoned it was a no-op since marking one message read twice changes nothing, but under a filter such as `f u` each marked message leaves the view and the next takes its place, so `3 m r` walks three messages. Repetition restored.

### Additional testing for this commit

- `m s` on a single message stars it once, with no visible on/off/on.
- `m s`, `m j`, `m p` and `m R` leave read state as it was - the leaked `m` no longer shows through.
- `m r` and `m u` still set read state correctly, and `m j` actually toggles junk now.
- Under `f u`, `3 m r` marks three successive messages read.
- `.` after `m s` stars without disturbing read state.
