### PR TITLE
feat(tbkeys): add Vim-style ":" command-line mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Vim-style keybindings for Betterbird, provided by the tbkeys add-on. Two locatio
 - `home/thunderbird/tbkeys/keys.json` - the keymap, one line per binding.
 - `home/thunderbird/.config/tbkeys/*.js` - the code the bindings call, split into cohesive feature modules. Stowed to `~/.config/tbkeys/` by the `thunderbird` package, and loaded automatically each time Betterbird starts.
 
-`system/opt/betterbird/betterbird.cfg` resolves `~/.config/tbkeys/` once per window and loads the modules through `Services.scriptloader.loadSubScriptWithOptions` in a fixed dependency order: `core.js`, `selection.js`, `folders.js`, `motions.js`, `navigation.js`, `actions.js`, `search.js`, `ui.js`, `whichkey.js`. A missing or failing module logs which file it was rather than a generic error, and loading stops there for that window.
+`system/opt/betterbird/betterbird.cfg` resolves `~/.config/tbkeys/` once per window and loads the modules through `Services.scriptloader.loadSubScriptWithOptions` in a fixed dependency order: `core.js`, `selection.js`, `folders.js`, `motions.js`, `navigation.js`, `actions.js`, `search.js`, `command.js`, `ui.js`, `whichkey.js`. A missing or failing module logs which file it was rather than a generic error, and loading stops there for that window.
 
-Each module is `(function (tk) { "use strict"; ... })(window.tk);`, populating the shared `window.tk` namespace rather than using ES modules, imports, a bundler, or a build step. `core.js` is the exception: it first calls `window.tk?.whichkey_teardown?.()` so a reload doesn't leak the previous which-key listener, then creates a fresh `window.tk = {}` before populating it, so a reload never carries stale functions from a previous version.
+Each module is `(function (tk) { "use strict"; ... })(window.tk);`, populating the shared `window.tk` namespace rather than using ES modules, imports, a bundler, or a build step. `core.js` is the exception: it first runs the teardown hooks the previous load left behind (`whichkey_teardown`, `ui_teardown`, `command_teardown`) so a reload doesn't leak listeners or injected elements, then creates a fresh `window.tk = {}` before populating it, so a reload never carries stale functions from a previous version.
 
 Module responsibilities, following a one-way dependency direction (later modules may call into earlier ones, never the reverse):
 
@@ -70,6 +70,7 @@ Module responsibilities, following a one-way dependency direction (later modules
 - `navigation.js` - higher-level stepping (unread/thread/starred/attachment), focus switching, and tab navigation.
 - `actions.js` - message mutations (read/unread/flag/junk/delete/archive/move) and `.` repeat-last-action.
 - `search.js` - incremental folder search (state, input, highlighting, matching, accept/cancel/step) and `tk_escape`, since escape is mostly search cleanup.
+- `command.js` - the Vim-style `:` command line: input UI, parser, and a declarative command registry (`archive`, `move`, `filter`, `open`) that calls into the existing folder/action helpers rather than duplicating them.
 - `ui.js` - the persistent mode/count/status indicator. Kept small on purpose; feature-specific UI lives with its feature instead.
 - `whichkey.js` - the passive which-key overlay: chord trie, timers, and transient rendering. Loaded last, and fires the initial `tk.repaint_mode()` once every module is in place. Visualization only - it never touches Mousetrap or tbkeys keyboard dispatch.
 

--- a/home/thunderbird/.config/tbkeys/actions.js
+++ b/home/thunderbird/.config/tbkeys/actions.js
@@ -58,15 +58,22 @@
     const is_junk = range.anchor_hdr.getStringProperty("junkscore") === "100";
     tk.run_view_command(tt, is_junk ? "unjunk" : "junk");
   });
-  window.tk_move_to_projects = m_chord((tt, range) => {
-    const folder = tk.find_folder_by_name(tk.PROJECTS_FOLDER);
-    if (!folder) return;
-    tt?.view?.doCommandWithFolder?.(
-      window.Ci.nsMsgViewCommandType.moveMessages,
-      folder,
-    );
-    return range.top_index;
-  });
+  /**
+   * @param {Object} folder - folder to move the current message or visual selection into; a no-op when null
+   * @returns {Function} m_chord handler that performs the move
+   */
+  tk.move_to_folder = (folder) =>
+    m_chord((tt, range) => {
+      if (!folder) return;
+      tt?.view?.doCommandWithFolder?.(
+        window.Ci.nsMsgViewCommandType.moveMessages,
+        folder,
+      );
+      return range.top_index;
+    });
+
+  window.tk_move_to_projects = () =>
+    tk.move_to_folder(tk.find_folder_by_name(tk.PROJECTS_FOLDER))();
 
   window.tk_delete = act_over_range("cmd_delete");
   window.tk_archive = act_over_range("cmd_archive");

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -129,9 +129,10 @@
     const input = doc.createElement("input");
     input.id = "tbkeys-command-input";
     input.type = "text";
+    input.setAttribute("aria-label", "tbkeys command");
     input.style.cssText =
       "flex:1; font:inherit; background:#222; color:#fff; " +
-      "border:1px solid #666; padding:2px 4px; outline:none;";
+      "border:1px solid #666; padding:2px 4px;";
     bar.appendChild(label);
     bar.appendChild(input);
     (doc.body ?? doc.documentElement).appendChild(bar);

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -1,0 +1,205 @@
+// Vim-style ":" command line: input UI -> parser -> command registry ->
+// existing helper APIs. tk_command_line opens it; Enter/Escape close it.
+(function (tk) {
+  "use strict";
+
+  // -- parser ---------------------------------------------------------------
+
+  /**
+   * Splits a command line into a lowercased name and whitespace-split args, with support for double-quoted segments.
+   * @param {string} text - raw command-line input, without the leading ":"
+   * @returns {{name: string, args: string[]}}
+   */
+  tk.parse_command = (text) => {
+    const trimmed = (text ?? "").trim();
+    if (!trimmed) return { name: "", args: [] };
+    const space_idx = trimmed.search(/\s/);
+    const name = (
+      space_idx === -1 ? trimmed : trimmed.slice(0, space_idx)
+    ).toLowerCase();
+    const rest = space_idx === -1 ? "" : trimmed.slice(space_idx + 1).trim();
+    const args = [];
+    const re = /"([^"]*)"|(\S+)/g;
+    let m;
+    while ((m = re.exec(rest))) args.push(m[1] ?? m[2]);
+    return { name, args };
+  };
+
+  // -- command registry -------------------------------------------------------
+
+  tk.command_aliases = { a: "archive", mv: "move", e: "open" };
+
+  /**
+   * @param {string} name - command name or alias, already lowercased
+   * @returns {Object} the matching command definition, or undefined
+   */
+  tk.resolve_command = (name) => {
+    const key = Object.hasOwn(tk.command_aliases, name)
+      ? tk.command_aliases[name]
+      : name;
+    return Object.hasOwn(tk.commands, key) ? tk.commands[key] : undefined;
+  };
+
+  tk.commands = {
+    archive: {
+      usage: "archive",
+      description: "Archive the current message or visual selection",
+      run: ({ args }) => {
+        if (args.length) return tk.commands.archive.usage;
+        window.tk_archive();
+      },
+    },
+    move: {
+      usage: "move <folder>",
+      description: "Move the current message or visual selection to a folder",
+      run: ({ args }) => {
+        const name = args.join(" ");
+        if (!name) return tk.commands.move.usage;
+        const folder = tk.find_folder_by_name(name);
+        if (!folder) return `No folder matching "${name}"`;
+        tk.move_to_folder(folder)();
+      },
+    },
+    filter: {
+      usage: "filter <unread|all|starred>",
+      description: "Apply a message view filter",
+      run: ({ args }) => {
+        const filters = {
+          unread: () => window.goDoCommand("cmd_viewUnreadMsgs"),
+          all: () => window.goDoCommand("cmd_viewAllMsgs"),
+          starred: () => window.tk_toggle_starred_filter(),
+        };
+        if (!args.length) return tk.commands.filter.usage;
+        const fn = filters[args[0]];
+        if (!fn)
+          return `Unknown filter "${args[0]}" (valid: ${Object.keys(filters).join(", ")})`;
+        fn();
+      },
+    },
+    open: {
+      usage: "open <folder>",
+      description: "Open a folder by name",
+      run: ({ args }) => {
+        const name = args.join(" ");
+        if (!name) return tk.commands.open.usage;
+        const folder = tk.find_folder_by_name(name);
+        if (!folder) return `No folder matching "${name}"`;
+        tk.show_folder(folder);
+      },
+    },
+  };
+
+  /**
+   * Parses and runs a full command-line string, reporting an unknown command
+   * or a handler's returned error string via window.alert.
+   * @param {string} text - raw command-line input, without the leading ":"
+   */
+  tk.execute_command_text = (text) => {
+    const { name, args } = tk.parse_command(text);
+    if (!name) return;
+    const cmd = tk.resolve_command(name);
+    if (!cmd) {
+      window.alert(`Unknown command ":${name}"`);
+      return;
+    }
+    const error = cmd.run({ args });
+    if (error) window.alert(error);
+  };
+
+  // -- input UI ---------------------------------------------------------------
+
+  tk.command_mode_prior = null;
+
+  /**
+   * @returns {Element} the injected command bar, creating it (with its input) if absent
+   */
+  tk.ensure_command_bar = () => {
+    const doc = window.document;
+    let bar = doc.getElementById("tbkeys-command-bar");
+    if (bar) return bar;
+    bar = doc.createElement("div");
+    bar.id = "tbkeys-command-bar";
+    bar.style.cssText =
+      "position:fixed; left:0; right:0; bottom:0; z-index:2147483647; " +
+      "display:flex; align-items:center; gap:4px; " +
+      "background:#0C0E13; border-top:1px solid #333; " +
+      "font:12px monospace; padding:4px 8px; color:#fff;";
+    const label = doc.createElement("span");
+    label.textContent = ":";
+    const input = doc.createElement("input");
+    input.id = "tbkeys-command-input";
+    input.type = "text";
+    input.style.cssText =
+      "flex:1; font:inherit; background:#222; color:#fff; " +
+      "border:1px solid #666; padding:2px 4px; outline:none;";
+    bar.appendChild(label);
+    bar.appendChild(input);
+    (doc.body ?? doc.documentElement).appendChild(bar);
+    return bar;
+  };
+
+  tk.close_command_bar = () => {
+    window.document.getElementById("tbkeys-command-bar")?.remove();
+  };
+
+  /**
+   * @param {KeyboardEvent} e
+   */
+  tk.command_input_keydown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      tk.finish_command_line(true, e.target.value);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      tk.finish_command_line(false, "");
+    }
+  };
+
+  /**
+   * Closes the command line, restoring the vim mode that was active when ":"
+   * was pressed before anything else runs, since focusing the input forced
+   * insert mode and a handler acting on a visual range must see it restored.
+   * @param {boolean} execute - true to parse and run `text`, false to just cancel
+   * @param {string} text - raw command-line input, without the leading ":"
+   */
+  tk.finish_command_line = (execute, text) => {
+    if (!window.document.getElementById("tbkeys-command-bar")) return;
+    const prior = tk.command_mode_prior ?? "normal";
+    tk.command_mode_prior = null;
+    window.vim = prior;
+    tk.mode_before_insert = null;
+    tk.close_command_bar();
+    window.tk_focus_thread_tree();
+    tk.sync_insert_mode();
+    tk.repaint_mode();
+    if (execute) tk.execute_command_text(text);
+  };
+
+  /**
+   * @param {FocusEvent} e
+   */
+  tk.command_input_focusout = (e) => {
+    // relatedTarget is null when the whole window deactivates, which should
+    // leave a half-typed command alone rather than cancelling it.
+    if (e.relatedTarget) tk.finish_command_line(false, "");
+  };
+
+  tk.command_teardown = () => {
+    if (window.document.getElementById("tbkeys-command-bar"))
+      window.vim = tk.command_mode_prior ?? "normal";
+    tk.close_command_bar();
+  };
+
+  // -- flat tk_* functions for keys.json "func:" bindings ------------------
+
+  window.tk_command_line = () => {
+    tk.reset_count();
+    tk.command_mode_prior = window.vim ?? "normal";
+    tk.ensure_command_bar();
+    const input = window.document.getElementById("tbkeys-command-input");
+    input.value = "";
+    input.onkeydown = tk.command_input_keydown;
+    input.onfocusout = tk.command_input_focusout;
+    input.focus();
+  };
+})(window.tk);

--- a/home/thunderbird/.config/tbkeys/core.js
+++ b/home/thunderbird/.config/tbkeys/core.js
@@ -6,6 +6,7 @@
 
   window.tk?.whichkey_teardown?.();
   window.tk?.ui_teardown?.();
+  window.tk?.command_teardown?.();
   window.tk = {};
 })();
 

--- a/home/thunderbird/.config/tbkeys/folders.js
+++ b/home/thunderbird/.config/tbkeys/folders.js
@@ -30,12 +30,15 @@
     const pane = window.gTabmail?.currentAbout3Pane;
     if (!pane) return;
     const current_uri = pane.gFolder?.URI;
-    if (!tk.jumping && current_uri && current_uri !== folder.URI) {
+    const changed = !!current_uri && current_uri !== folder.URI;
+    if (!tk.jumping && changed) {
       tk.jump_back_stack.push(current_uri);
       if (tk.jump_back_stack.length > JUMP_LIST_MAX) tk.jump_back_stack.shift();
       tk.jump_forward_stack = [];
     }
     pane.displayFolder?.(folder);
+    // Anchor/end name rows in the folder being left, so they cannot survive it.
+    if (changed && tk.is_visual()) tk.exit_visual();
   };
 
   /**

--- a/home/thunderbird/.config/tbkeys/navigation.js
+++ b/home/thunderbird/.config/tbkeys/navigation.js
@@ -18,10 +18,7 @@
     const folder_after =
       window.gTabmail?.currentAbout3Pane?.gFolder?.URI ?? null;
     if (folder_before !== folder_after) {
-      window.vim = "normal";
-      window.visualAnchor = undefined;
-      window.visualEnd = undefined;
-      tk.repaint_mode();
+      tk.exit_visual();
       return;
     }
     if (typeof tt?.currentIndex !== "number" || tt.currentIndex < 0) return;

--- a/home/thunderbird/.config/tbkeys/selection.js
+++ b/home/thunderbird/.config/tbkeys/selection.js
@@ -64,6 +64,16 @@
   };
 
   /**
+   * Leaves visual mode and drops the recorded anchor/end without touching the tree selection, for a context change that makes those row indices meaningless.
+   */
+  tk.exit_visual = () => {
+    window.vim = "normal";
+    window.visualAnchor = undefined;
+    window.visualEnd = undefined;
+    tk.repaint_mode();
+  };
+
+  /**
    * Exits visual mode and collapses the tree selection to a single row after an action ran over a range.
    * @param {Element} tt - the thread tree
    * @param {number} cursor_index - row to select, clamped to the surviving row count

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -112,6 +112,7 @@
     ["n", "Next search match"],
     ["N", "Previous search match"],
     [";", "Open conversation"],
+    [":", "Command line"],
     ["G", "Go to bottom"],
     [".", "Repeat last action"],
     ["0-9", "Count prefix"],

--- a/home/thunderbird/tbkeys/keys.json
+++ b/home/thunderbird/tbkeys/keys.json
@@ -72,6 +72,7 @@
   "n": "func:tk_search_next",
   "N": "func:tk_search_prev",
   ";": "cmd:cmd_openConversation",
+  ":": "func:tk_command_line",
   "alt+h": "func:tk_focus_thread_tree",
   "alt+l": "func:tk_focus_message_pane",
   "ctrl+h": "tbkeys:closeMessageAndRefresh",

--- a/system/opt/betterbird/betterbird.cfg
+++ b/system/opt/betterbird/betterbird.cfg
@@ -12,6 +12,7 @@ try {
     "navigation.js",
     "actions.js",
     "search.js",
+    "command.js",
     "ui.js",
     "whichkey.js",
   ];


### PR DESCRIPTION
Closes #88.

## What

Adds a `:` command line to the tbkeys Betterbird runtime, as an extensible escape hatch for actions that do not justify a permanent chord.

New module `home/thunderbird/.config/tbkeys/command.js`, keeping the three concerns separate as the issue asks:

- **Input UI** - a transient bar injected into the chrome window, fixed to the bottom, with a `:` label and a focused `<input>`. Being an `<input>` is what keeps normal-mode bindings from firing while typing: tbkeys' own stopCallback and `tk.is_text_input` already exempt it, the same mechanism `search.js` relies on. No key-swallowing hacks were added.
- **Parser** - `tk.parse_command` splits a lowercased command name from whitespace-separated arguments, with double-quote support so `:move "Some Folder"` works.
- **Registry** - `tk.commands` maps names to `{usage, description, run}`, with `tk.command_aliases` (`a`, `mv`, `e`) pointing at the same definitions rather than duplicating handlers. Adding a command means adding an entry, not touching the parser.
- **Handlers** - call the existing helper APIs. `:archive` goes through `window.tk_archive`, `:move` through the shared move path, `:open` through `tk.show_folder` and its jump list, `:filter` through the existing view commands.

Initial commands: `:archive`, `:move <folder>`, `:filter <unread|all|starred>`, `:open <folder>`.

`tk_move_to_projects` is refactored into `tk.move_to_folder(folder)` so `:move` and the `m p` chord share one `doCommandWithFolder` implementation.

## Mode and focus handling

The one genuinely tricky part. Focusing the command input makes `ui.js` set `window.vim = "insert"`, so a handler that calls `tk.resolve_action_range` would see no visual mode and fall back to the single current row. `tk.finish_command_line` therefore restores the mode that was active when `:` was pressed, closes the bar and returns focus to the thread tree, and only then runs the command - so `:archive` and `:move` act on a visual selection exactly like their chord equivalents.

Cancelling restores that mode too, so a visual selection survives an abandoned command line, matching `ui.js`'s existing intent that a selection survives a trip through a text field. Focus leaving the input cancels the command line, but window deactivation does not, so a half-typed command is not lost to an alt-tab.

## Related fix, slightly beyond the issue

`tk.show_folder` now leaves visual mode whenever it actually changes folder, through a new `tk.exit_visual` that `navigation.js` already needed and now reuses.

Visual anchor/end are row indices into the folder being left. `tk.resolve_action_range` clamps them rather than discarding them, so carrying them across a folder switch could silently act on an unintended range in the new folder. `tk.run_navigation_command` already guarded against this; `tk.show_folder` did not. Fixing it at that layer covers `:open` and the pre-existing `g i`, `g t`, `g o`, folder mark and `ctrl+o` paths at once, instead of adding a second copy of the same guard inside the new command.

## Wiring

- `keys.json`: `":": "func:tk_command_line"`.
- `betterbird.cfg`: `command.js` added to `MODULE_MANIFEST`, between `search.js` and `ui.js`.
- `whichkey.js`: `:` added to the `?` command list.
- `core.js`: `command_teardown` joins the existing reload teardown hooks, and restores the pre-`:` mode if a reload happens while the bar is open.
- `README.md`: module list and dependency order updated.

## Review

Reviewed twice - once by hand and once with Codex - and the findings were reconciled. Both flagged that quoted folder arguments reached the folder lookup with their quotes attached; Codex additionally found the stale-visual-state-across-folder-switch issue described above and a registry lookup that could reach inherited `Object.prototype` members, and the manual pass found that the bar could be left open and unfocused if focus moved away without Enter or Escape. All are fixed here.

## Testing

Betterbird cannot be driven in this environment, so verification is static: `node --check` on every changed JS file and on `betterbird.cfg`, a JSON parse of `keys.json`, and a Prettier check confirming no new formatting divergence (three files carry pre-existing warnings from deliberately unwrapped JSDoc lines). The behavior itself needs a manual pass in Betterbird.
