### PR TITLE
feat(tbkeys): add :help and a completion menu to command mode

### DIFF
--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -27,7 +27,7 @@
 
   // -- command registry -------------------------------------------------------
 
-  tk.command_aliases = { a: "archive", mv: "move" };
+  tk.command_aliases = { mv: "move" };
 
   /**
    * @param {string} name - command name or alias, already lowercased

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -56,7 +56,17 @@
 
   // Folder names may contain spaces, so move/open treat everything after the
   // command name as one token rather than splitting args on whitespace.
-  const complete_folder_names = () => tk.all_folders().map((f) => f.name);
+  let folder_names = null;
+
+  /**
+   * Enumerating every account's descendants on each keystroke is the one
+   * expensive completion source, so it is held for one command-line session.
+   * @returns {string[]} every folder name, cached until the bar closes
+   */
+  const complete_folder_names = () => {
+    folder_names ??= tk.all_folders().map((f) => f.name);
+    return folder_names;
+  };
 
   tk.commands = {
     archive: {
@@ -343,7 +353,7 @@
     bar.style.cssText =
       "position:fixed; left:0; right:0; bottom:0; z-index:2147483647; " +
       "display:flex; flex-direction:column; align-items:stretch; " +
-      "background:#0C0E13; border-top:1px solid #333; " +
+      `background:${tk.whichkey_colors.bg}; border-top:1px solid #333; ` +
       "font:12px monospace; color:#fff;";
 
     const menu = doc.createElement("div");
@@ -373,6 +383,7 @@
 
   tk.close_command_bar = () => {
     tk.command_completion = null;
+    folder_names = null;
     window.document.getElementById("tbkeys-command-bar")?.remove();
   };
 

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -27,7 +27,7 @@
 
   // -- command registry -------------------------------------------------------
 
-  tk.command_aliases = { a: "archive", mv: "move", e: "open" };
+  tk.command_aliases = { a: "archive", mv: "move" };
 
   /**
    * @param {string} name - command name or alias, already lowercased
@@ -407,16 +407,24 @@
   };
 
   /**
-   * @param {InputEvent} e
+   * Recomputes the menu from `value` with nothing highlighted; an empty value
+   * lists every command, so ":" opens onto the full set.
+   * @param {string} value - raw command-line input
    */
-  tk.command_input_input = (e) => {
-    const value = e.target.value;
-    const computed = value ? tk.compute_completion(value) : null;
+  tk.refresh_completion = (value) => {
+    const computed = tk.compute_completion(value);
     tk.command_completion =
       computed && computed.candidates.length
         ? { ...computed, index: -1 }
         : null;
     tk.render_command_menu();
+  };
+
+  /**
+   * @param {InputEvent} e
+   */
+  tk.command_input_input = (e) => {
+    tk.refresh_completion(e.target.value);
   };
 
   /**
@@ -479,8 +487,7 @@
     tk.ensure_command_bar();
     const input = window.document.getElementById("tbkeys-command-input");
     input.value = "";
-    tk.command_completion = null;
-    tk.render_command_menu();
+    tk.refresh_completion("");
     input.onkeydown = tk.command_input_keydown;
     input.oninput = tk.command_input_input;
     input.onfocusout = tk.command_input_focusout;

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -40,6 +40,17 @@
     return Object.hasOwn(tk.commands, key) ? tk.commands[key] : undefined;
   };
 
+  // Shared with filter's complete(), so run and completion never drift apart.
+  const FILTERS = {
+    unread: () => window.goDoCommand("cmd_viewUnreadMsgs"),
+    all: () => window.goDoCommand("cmd_viewAllMsgs"),
+    starred: () => window.tk_toggle_starred_filter(),
+  };
+
+  // Folder names may contain spaces, so move/open treat everything after the
+  // command name as one token rather than splitting args on whitespace.
+  const complete_folder_names = () => tk.all_folders().map((f) => f.name);
+
   tk.commands = {
     archive: {
       usage: "archive",
@@ -52,6 +63,8 @@
     move: {
       usage: "move <folder>",
       description: "Move the current message or visual selection to a folder",
+      complete_rest: true,
+      complete: () => complete_folder_names(),
       run: ({ args }) => {
         const name = args.join(" ");
         if (!name) return tk.commands.move.usage;
@@ -63,28 +76,47 @@
     filter: {
       usage: "filter <unread|all|starred>",
       description: "Apply a message view filter",
+      complete: () => Object.keys(FILTERS),
       run: ({ args }) => {
-        const filters = {
-          unread: () => window.goDoCommand("cmd_viewUnreadMsgs"),
-          all: () => window.goDoCommand("cmd_viewAllMsgs"),
-          starred: () => window.tk_toggle_starred_filter(),
-        };
         if (!args.length) return tk.commands.filter.usage;
-        const fn = filters[args[0]];
+        const fn = FILTERS[args[0]];
         if (!fn)
-          return `Unknown filter "${args[0]}" (valid: ${Object.keys(filters).join(", ")})`;
+          return `Unknown filter "${args[0]}" (valid: ${Object.keys(FILTERS).join(", ")})`;
         fn();
       },
     },
     open: {
       usage: "open <folder>",
       description: "Open a folder by name",
+      complete_rest: true,
+      complete: () => complete_folder_names(),
       run: ({ args }) => {
         const name = args.join(" ");
         if (!name) return tk.commands.open.usage;
         const folder = tk.find_folder_by_name(name);
         if (!folder) return `No folder matching "${name}"`;
         tk.show_folder(folder);
+      },
+    },
+    help: {
+      usage: "help [command]",
+      description: "List commands, or show one command in detail",
+      complete: () => [
+        ...Object.keys(tk.commands),
+        ...Object.keys(tk.command_aliases),
+      ],
+      run: ({ args }) => {
+        if (!args.length) {
+          render_command_help();
+          return;
+        }
+        const typed = args[0].toLowerCase();
+        const cmd = tk.resolve_command(typed);
+        if (!cmd) return `Unknown command ":${typed}"`;
+        const canonical = Object.hasOwn(tk.command_aliases, typed)
+          ? tk.command_aliases[typed]
+          : typed;
+        render_command_help(canonical);
       },
     },
   };
@@ -106,12 +138,174 @@
     if (error) window.alert(error);
   };
 
+  // -- completion ---------------------------------------------------------
+
+  /**
+   * Orders candidates prefix matches first, then substring matches, each
+   * group alphabetical, de-duplicated.
+   * @param {string[]} names - candidate strings
+   * @param {string} prefix - raw text being completed, matched case-insensitively
+   * @returns {string[]} ordered, de-duplicated candidates
+   */
+  tk.filter_candidates = (names, prefix) => {
+    const target = prefix.toLowerCase();
+    const unique = [...new Set(names)];
+    const starts = unique
+      .filter((n) => n.toLowerCase().startsWith(target))
+      .sort();
+    const contains = unique
+      .filter(
+        (n) =>
+          !n.toLowerCase().startsWith(target) &&
+          n.toLowerCase().includes(target),
+      )
+      .sort();
+    return [...starts, ...contains];
+  };
+
+  /**
+   * Decides, from the raw (untrimmed) command-line value, what is being
+   * completed: command/alias names when there is no whitespace yet,
+   * otherwise a resolved command's own complete() candidates.
+   * @param {string} value - raw command-line input
+   * @returns {{token_start: number, candidates: string[]}} completion state, or null when nothing can be completed
+   */
+  tk.compute_completion = (value) => {
+    if (!/\s/.test(value)) {
+      const names = [
+        ...Object.keys(tk.commands),
+        ...Object.keys(tk.command_aliases),
+      ];
+      return { token_start: 0, candidates: tk.filter_candidates(names, value) };
+    }
+    const space_idx = value.search(/\s/);
+    const cmd_name = value.slice(0, space_idx).toLowerCase();
+    const cmd = tk.resolve_command(cmd_name);
+    if (!cmd || typeof cmd.complete !== "function") return null;
+    const lead = value.slice(space_idx).match(/^\s*/)[0].length;
+    const rest_start = space_idx + lead;
+    const rest = value.slice(rest_start);
+    let token_start, prefix;
+    if (cmd.complete_rest) {
+      token_start = rest_start;
+      prefix = rest;
+    } else {
+      const m = rest.match(/\S*$/);
+      token_start = rest_start + m.index;
+      prefix = m[0];
+    }
+    const { args } = tk.parse_command(value);
+    const candidates = tk.filter_candidates(
+      cmd.complete({ args, prefix }) ?? [],
+      prefix,
+    );
+    return { token_start, candidates };
+  };
+
+  // -- help panel ---------------------------------------------------------
+
+  /**
+   * @returns {Element} the injected :help panel, creating it if absent
+   */
+  const ensure_command_help_panel = () => {
+    const doc = window.document;
+    let el = doc.getElementById("tbkeys-command-help");
+    if (el) return el;
+    el = doc.createElement("div");
+    el.id = "tbkeys-command-help";
+    el.style.cssText =
+      "position:fixed; right:12px; bottom:32px; z-index:2147483647; " +
+      `background:${tk.whichkey_colors.bg}; border:1px solid #333; ` +
+      "font:12px monospace; padding:6px 10px; pointer-events:none;";
+    (doc.body ?? doc.documentElement).appendChild(el);
+    return el;
+  };
+
+  /**
+   * @param {Document} doc - owner document to create the row in
+   * @param {string} key - command name, canonical
+   * @returns {Element} one command's help row: names in the key color, usage/description in the label color
+   */
+  const command_help_row = (doc, key) => {
+    const cmd = tk.commands[key];
+    const aliases = Object.entries(tk.command_aliases)
+      .filter(([, target]) => target === key)
+      .map(([alias]) => alias);
+    const names = [key, ...aliases].join(", ");
+    return tk.whichkey_entry_row(
+      doc,
+      names,
+      `${cmd.usage} -- ${cmd.description}`,
+      tk.whichkey_colors.label,
+    );
+  };
+
+  let command_help_dismiss = null;
+
+  /**
+   * Installs the capture-phase keydown listener that removes the :help panel
+   * on the next key press; a no-op while one is already installed.
+   */
+  const install_command_help_dismiss = () => {
+    if (command_help_dismiss) return;
+    command_help_dismiss = () => remove_command_help();
+    window.addEventListener("keydown", command_help_dismiss, {
+      capture: true,
+    });
+  };
+
+  /**
+   * Removes the :help panel and its dismiss listener, if present.
+   */
+  const remove_command_help = () => {
+    if (command_help_dismiss) {
+      window.removeEventListener("keydown", command_help_dismiss, {
+        capture: true,
+      });
+      command_help_dismiss = null;
+    }
+    window.document.getElementById("tbkeys-command-help")?.remove();
+  };
+
+  /**
+   * Renders the :help panel: every command sorted by name, or just `name`.
+   * @param {string} [name] - canonical command name to show alone
+   */
+  const render_command_help = (name) => {
+    const panel = ensure_command_help_panel();
+    const doc = panel.ownerDocument;
+    panel.textContent = "";
+    if (name) {
+      panel.appendChild(
+        tk.whichkey_text_row(
+          doc,
+          `:help -- ${name} --`,
+          tk.whichkey_colors.header,
+        ),
+      );
+      panel.appendChild(command_help_row(doc, name));
+    } else {
+      panel.appendChild(
+        tk.whichkey_text_row(
+          doc,
+          ":help -- commands --",
+          tk.whichkey_colors.header,
+        ),
+      );
+      for (const key of Object.keys(tk.commands).sort())
+        panel.appendChild(command_help_row(doc, key));
+    }
+    panel.style.display = "block";
+    install_command_help_dismiss();
+  };
+
   // -- input UI ---------------------------------------------------------------
 
   tk.command_mode_prior = null;
+  tk.command_completion = null;
 
   /**
-   * @returns {Element} the injected command bar, creating it (with its input) if absent
+   * @returns {Element} the injected command bar, creating it (with its menu and input) if absent
    */
   tk.ensure_command_bar = () => {
     const doc = window.document;
@@ -121,9 +315,17 @@
     bar.id = "tbkeys-command-bar";
     bar.style.cssText =
       "position:fixed; left:0; right:0; bottom:0; z-index:2147483647; " +
-      "display:flex; align-items:center; gap:4px; " +
+      "display:flex; flex-direction:column; align-items:stretch; " +
       "background:#0C0E13; border-top:1px solid #333; " +
-      "font:12px monospace; padding:4px 8px; color:#fff;";
+      "font:12px monospace; color:#fff;";
+
+    const menu = doc.createElement("div");
+    menu.id = "tbkeys-command-menu";
+    menu.style.cssText = "display:none; pointer-events:none; padding:2px 8px;";
+
+    const row = doc.createElement("div");
+    row.style.cssText =
+      "display:flex; align-items:center; gap:4px; padding:4px 8px;";
     const label = doc.createElement("span");
     label.textContent = ":";
     const input = doc.createElement("input");
@@ -133,21 +335,98 @@
     input.style.cssText =
       "flex:1; font:inherit; background:#222; color:#fff; " +
       "border:1px solid #666; padding:2px 4px;";
-    bar.appendChild(label);
-    bar.appendChild(input);
+    row.appendChild(label);
+    row.appendChild(input);
+
+    bar.appendChild(menu);
+    bar.appendChild(row);
     (doc.body ?? doc.documentElement).appendChild(bar);
     return bar;
   };
 
   tk.close_command_bar = () => {
+    tk.command_completion = null;
     window.document.getElementById("tbkeys-command-bar")?.remove();
+  };
+
+  /**
+   * Repaints the completion menu from tk.command_completion; hidden when
+   * there is no candidate to show.
+   */
+  tk.render_command_menu = () => {
+    const menu = window.document.getElementById("tbkeys-command-menu");
+    if (!menu) return;
+    const state = tk.command_completion;
+    menu.textContent = "";
+    if (!state || !state.candidates.length) {
+      menu.style.display = "none";
+      return;
+    }
+    const doc = menu.ownerDocument;
+    const colors = tk.whichkey_colors;
+    state.candidates.forEach((candidate, i) => {
+      const row = doc.createElement("div");
+      row.textContent = candidate;
+      if (i === state.index) {
+        row.style.background = colors.key;
+        row.style.color = colors.bg;
+      } else {
+        row.style.color = colors.label;
+      }
+      menu.appendChild(row);
+    });
+    menu.style.display = "block";
+  };
+
+  /**
+   * @param {number} dir - +1 to cycle forward, -1 to cycle backward
+   */
+  tk.cycle_completion = (dir) => {
+    const input = window.document.getElementById("tbkeys-command-input");
+    if (!input) return;
+    if (!tk.command_completion) {
+      const computed = tk.compute_completion(input.value);
+      if (!computed || !computed.candidates.length) return;
+      tk.command_completion = { ...computed, index: -1 };
+    }
+    const state = tk.command_completion;
+    const n = state.candidates.length;
+    state.index =
+      state.index === -1
+        ? dir > 0
+          ? 0
+          : n - 1
+        : (((state.index + dir) % n) + n) % n;
+    const candidate = state.candidates[state.index];
+    // Deliberately not recomputed from the written value: the candidate list
+    // must stay put across cycles, or completing one entry strands the rest.
+    const new_value = input.value.slice(0, state.token_start) + candidate;
+    input.value = new_value;
+    input.setSelectionRange(new_value.length, new_value.length);
+    tk.render_command_menu();
+  };
+
+  /**
+   * @param {InputEvent} e
+   */
+  tk.command_input_input = (e) => {
+    const value = e.target.value;
+    const computed = value ? tk.compute_completion(value) : null;
+    tk.command_completion =
+      computed && computed.candidates.length
+        ? { ...computed, index: -1 }
+        : null;
+    tk.render_command_menu();
   };
 
   /**
    * @param {KeyboardEvent} e
    */
   tk.command_input_keydown = (e) => {
-    if (e.key === "Enter") {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      tk.cycle_completion(e.shiftKey ? -1 : 1);
+    } else if (e.key === "Enter") {
       e.preventDefault();
       tk.finish_command_line(true, e.target.value);
     } else if (e.key === "Escape") {
@@ -189,6 +468,7 @@
     if (window.document.getElementById("tbkeys-command-bar"))
       window.vim = tk.command_mode_prior ?? "normal";
     tk.close_command_bar();
+    remove_command_help();
   };
 
   // -- flat tk_* functions for keys.json "func:" bindings ------------------
@@ -199,7 +479,10 @@
     tk.ensure_command_bar();
     const input = window.document.getElementById("tbkeys-command-input");
     input.value = "";
+    tk.command_completion = null;
+    tk.render_command_menu();
     input.onkeydown = tk.command_input_keydown;
+    input.oninput = tk.command_input_input;
     input.onfocusout = tk.command_input_focusout;
     input.focus();
   };

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -27,7 +27,7 @@
 
   // -- command registry -------------------------------------------------------
 
-  tk.command_aliases = { mv: "move" };
+  tk.command_aliases = {};
 
   /**
    * @param {string} name - command name or alias, already lowercased
@@ -47,6 +47,13 @@
     starred: () => window.tk_toggle_starred_filter(),
   };
 
+  // Shared with focus's complete(), so run and completion never drift apart.
+  const PANES = {
+    folder: () => window.tk_focus_folder_tree(),
+    thread: () => window.tk_focus_thread_tree(),
+    message: () => window.tk_focus_message_pane(),
+  };
+
   // Folder names may contain spaces, so move/open treat everything after the
   // command name as one token rather than splitting args on whitespace.
   const complete_folder_names = () => tk.all_folders().map((f) => f.name);
@@ -58,6 +65,26 @@
       run: ({ args }) => {
         if (args.length) return tk.commands.archive.usage;
         window.tk_archive();
+      },
+    },
+    delete: {
+      usage: "delete",
+      description: "Delete the current message or visual selection",
+      run: ({ args }) => {
+        if (args.length) return tk.commands.delete.usage;
+        window.tk_delete();
+      },
+    },
+    focus: {
+      usage: "focus <folder|thread|message>",
+      description: "Move focus to a pane",
+      complete: () => Object.keys(PANES),
+      run: ({ args }) => {
+        if (!args.length) return tk.commands.focus.usage;
+        const fn = Object.hasOwn(PANES, args[0]) ? PANES[args[0]] : null;
+        if (!fn)
+          return `Unknown pane "${args[0]}" (valid: ${Object.keys(PANES).join(", ")})`;
+        fn();
       },
     },
     move: {
@@ -79,7 +106,7 @@
       complete: () => Object.keys(FILTERS),
       run: ({ args }) => {
         if (!args.length) return tk.commands.filter.usage;
-        const fn = FILTERS[args[0]];
+        const fn = Object.hasOwn(FILTERS, args[0]) ? FILTERS[args[0]] : null;
         if (!fn)
           return `Unknown filter "${args[0]}" (valid: ${Object.keys(FILTERS).join(", ")})`;
         fn();

--- a/home/thunderbird/.config/tbkeys/folders.js
+++ b/home/thunderbird/.config/tbkeys/folders.js
@@ -62,6 +62,19 @@
   };
 
   /**
+   * @returns {Object[]} every folder descending from every account's root folder
+   */
+  tk.all_folders = () => {
+    const folders = [];
+    for (const account of window.MailServices?.accounts?.accounts ?? []) {
+      const root = account.incomingServer?.rootFolder;
+      if (!root) continue;
+      for (const folder of root.descendants) folders.push(folder);
+    }
+    return folders;
+  };
+
+  /**
    * Searches every account for a folder named `name`, preferring an exact match over a substring one.
    * @param {string} name - folder name, matched case-insensitively
    * @returns {Object} the first matching folder, or null if none matches
@@ -69,14 +82,10 @@
   tk.find_folder_by_name = (name) => {
     const target = name.toLowerCase();
     let partial = null;
-    for (const account of window.MailServices?.accounts?.accounts ?? []) {
-      const root = account.incomingServer?.rootFolder;
-      if (!root) continue;
-      for (const folder of root.descendants) {
-        const folder_name = folder.name.toLowerCase();
-        if (folder_name === target) return folder;
-        if (!partial && folder_name.includes(target)) partial = folder;
-      }
+    for (const folder of tk.all_folders()) {
+      const folder_name = folder.name.toLowerCase();
+      if (folder_name === target) return folder;
+      if (!partial && folder_name.includes(target)) partial = folder;
     }
     return partial;
   };
@@ -100,7 +109,10 @@
    * @param {Object} marks - letter to folder URI map to persist
    */
   tk.save_marks = (marks) => {
-    window.Services?.prefs?.setStringPref?.(tk.MARK_PREF, JSON.stringify(marks));
+    window.Services?.prefs?.setStringPref?.(
+      tk.MARK_PREF,
+      JSON.stringify(marks),
+    );
   };
 
   /**

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -187,11 +187,13 @@
     window.document?.documentElement?.getAttribute("windowtype") ===
     "mail:3pane";
 
-  const WHICHKEY_BG = "#0C0E13";
-  const WHICHKEY_HEADER_COLOR = "#8A93A0";
-  const WHICHKEY_KEY_COLOR = "#D8CF7F";
-  const WHICHKEY_GROUP_COLOR = "#FFA0A0";
-  const WHICHKEY_LABEL_COLOR = "#B0C8DE";
+  tk.whichkey_colors = {
+    bg: "#0C0E13",
+    header: "#8A93A0",
+    key: "#D8CF7F",
+    group: "#FFA0A0",
+    label: "#B0C8DE",
+  };
 
   /**
    * @returns {Element} the injected which-key panel, creating it if absent
@@ -204,7 +206,7 @@
     el.id = "tbkeys-whichkey";
     el.style.cssText =
       "position:fixed; right:12px; bottom:32px; z-index:2147483647; " +
-      `background:${WHICHKEY_BG}; border:1px solid #333; ` +
+      `background:${tk.whichkey_colors.bg}; border:1px solid #333; ` +
       "font:12px monospace; padding:6px 10px; " +
       "pointer-events:none; display:none;";
     (doc.body ?? doc.documentElement).appendChild(el);
@@ -226,7 +228,7 @@
 
   /**
    * @param {Document} doc - owner document to create the row in
-   * @param {string} key - key character(s), always colored WHICHKEY_KEY_COLOR
+   * @param {string} key - key character(s), always colored tk.whichkey_colors.key
    * @param {string} label - description, colored `label_color`
    * @param {string} label_color - CSS color for the label half
    * @returns {Element} a which-key row with the key and label colored separately
@@ -235,7 +237,7 @@
     const row = doc.createElement("div");
     const key_span = doc.createElement("span");
     key_span.textContent = `  ${key}  `;
-    key_span.style.color = WHICHKEY_KEY_COLOR;
+    key_span.style.color = tk.whichkey_colors.key;
     const label_span = doc.createElement("span");
     label_span.textContent = label;
     label_span.style.color = label_color;
@@ -256,7 +258,7 @@
     const doc = el.ownerDocument;
     el.textContent = "";
     el.appendChild(
-      tk.whichkey_text_row(doc, path.join(" "), WHICHKEY_HEADER_COLOR),
+      tk.whichkey_text_row(doc, path.join(" "), tk.whichkey_colors.header),
     );
     for (const [key, node] of Object.entries(children)) {
       const is_group = !!node.children;
@@ -266,7 +268,7 @@
           doc,
           key,
           label,
-          is_group ? WHICHKEY_GROUP_COLOR : WHICHKEY_LABEL_COLOR,
+          is_group ? tk.whichkey_colors.group : tk.whichkey_colors.label,
         ),
       );
     }
@@ -282,7 +284,11 @@
     const doc = el.ownerDocument;
     el.textContent = "";
     el.appendChild(
-      tk.whichkey_text_row(doc, "? -- all commands --", WHICHKEY_HEADER_COLOR),
+      tk.whichkey_text_row(
+        doc,
+        "? -- all commands --",
+        tk.whichkey_colors.header,
+      ),
     );
     for (const key of Object.keys(tk.whichkey_trie.children ?? {})) {
       el.appendChild(
@@ -290,13 +296,13 @@
           doc,
           key,
           `+${tk.whichkey_group_labels[key] ?? "..."}`,
-          WHICHKEY_GROUP_COLOR,
+          tk.whichkey_colors.group,
         ),
       );
     }
     for (const [key, label] of WHICHKEY_SINGLES) {
       el.appendChild(
-        tk.whichkey_entry_row(doc, key, label, WHICHKEY_LABEL_COLOR),
+        tk.whichkey_entry_row(doc, key, label, tk.whichkey_colors.label),
       );
     }
     el.style.display = "block";


### PR DESCRIPTION
Closes #93.

Makes the `:` command line discoverable, using only data the registry from #88 already carries.

## `:help`

Lists every command sorted by name with its `usage`, `description` and the aliases pointing at it. `:help <command>` resolves through `resolve_command`, so it works on an alias, and shows that one entry.

It renders into its own `#tbkeys-command-help` panel rather than the which-key one. The visual language is shared — the color constants in `whichkey.js` are promoted to `tk.whichkey_colors` and the row helpers are reused unchanged — but the panel, its lifetime and its dismissal belong to `command.js`, so `:help` never reads or writes chord state. It is dismissed by the next keydown via a capture-phase listener that removes itself, and `command_teardown` removes both on reload.

## Completion menu

Lives inside the existing command bar, which becomes a column so the menu sits directly above the entry row. It is `pointer-events:none`: a click landing in it would blur the input and `command_input_focusout` would cancel the half-typed command.

Candidates recompute on every input event. `Tab`/`Shift+Tab` cycle in both directions, wrapping, writing the highlighted candidate into the input at the token being completed so arguments can still be typed after selecting. The list is deliberately not recomputed from the value a cycle just wrote — completing `m` to `move` would filter the list down to `move` alone and strand `mv`, making the cycle a dead end after one press.

What gets completed is decided from the raw, untrimmed value, so a trailing space means a fresh argument. With no whitespace yet the first token completes against command names and aliases; otherwise the resolved command's optional `complete()` supplies the candidates, ordered prefix matches first then substring, each group alphabetical.

## Argument completion

Covers the commands with a closed set of answers. `filter`'s map moves out of its `run()` to a module-level const so `run` and `complete` cannot drift apart. `move` and `open` complete folder names through a new `tk.all_folders()`, which `find_folder_by_name` is refactored onto rather than keeping a second traversal; its exact-match-beats-substring behavior is unchanged. Those two set `complete_rest`, since a folder name may contain spaces and everything after the command name is one token rather than a whitespace-split argument.

## Unchanged

`Escape` still closes the whole command line, as Tridactyl does, and `finish_command_line` remains the single exit path restoring the pre-`:` mode before any handler runs, so a visual selection still survives a cancelled command line. No chord or which-key behavior changes; `keys.json` is untouched.

Adding a new entry to `tk.commands` appears in both `:help` and completion with no other change.