### PR TITLE
fix(tbkeys): support unified inbox filters

### DIFF
--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -58,19 +58,11 @@
     bar.updateSearch?.();
   };
 
-  // The view filter and the quick filter bar are separate constraints, so
-  // "all" has to drop both or a tag or starred filter survives it.
-  const filter_all = () => {
-    tk.reset_count();
-    window.goDoCommand("cmd_viewAllMsgs");
-    window.gTabmail?.currentAbout3Pane?.quickFilterBar?._resetFilterState?.();
-  };
-
   // Shared with filter's complete(), so run and completion never drift apart.
   // Each takes the full argument list, since "tag" carries a name after it.
   const FILTERS = {
-    unread: () => window.goDoCommand("cmd_viewUnreadMsgs"),
-    all: () => filter_all(),
+    unread: () => tk.filter_unread(),
+    all: () => tk.filter_all(),
     starred: () => window.tk_toggle_starred_filter(),
     tag: (args) => filter_by_tag(args.slice(1).join(" ")),
   };
@@ -751,5 +743,4 @@
   window.tk_tag_picker = () => tk.open_command_line("tag ");
   window.tk_sort_picker = () => tk.open_command_line("sort ");
   window.tk_filter_picker = () => tk.open_command_line("filter ");
-  window.tk_filter_all = filter_all;
 })(window.tk);

--- a/home/thunderbird/.config/tbkeys/navigation.js
+++ b/home/thunderbird/.config/tbkeys/navigation.js
@@ -182,6 +182,7 @@
   tk.filter_all = () => {
     tk.reset_count();
     const pane = current_pane();
+    if (!pane) return "No message pane to filter";
     const controller = pane?.commandController;
     if (!controller) return "No message pane command controller";
     controller.doCommand("cmd_viewAllMsgs");

--- a/home/thunderbird/.config/tbkeys/navigation.js
+++ b/home/thunderbird/.config/tbkeys/navigation.js
@@ -149,6 +149,54 @@
       ?.click();
   };
 
+  // View commands are handled by about:3pane, not the top-level chrome
+  // window. The unread view command is disabled for virtual folders, so use
+  // the Quick Filter Bar's equivalent there (including unified folders).
+  const current_pane = () => window.gTabmail?.currentAbout3Pane;
+  const is_virtual_folder = (pane) =>
+    !!(
+      pane?.gFolder?.flags &
+      (window.Ci?.nsMsgFolderFlags?.Virtual ?? 0)
+    );
+
+  const apply_quick_filter = (pane, name, value) => {
+    const bar = pane?.quickFilterBar;
+    if (!bar?.filterer) return "No quick filter bar";
+    bar._showFilterBar?.(true);
+    bar.filterer.setFilterValue(name, value);
+    bar.reflectFiltererState?.();
+    bar.updateSearch?.();
+  };
+
+  tk.filter_unread = () => {
+    tk.reset_count();
+    const pane = current_pane();
+    if (!pane) return "No message pane to filter";
+    if (is_virtual_folder(pane))
+      return apply_quick_filter(pane, "unread", true);
+    const controller = pane.commandController;
+    if (!controller) return "No message pane command controller";
+    controller.doCommand("cmd_viewUnreadMsgs");
+  };
+
+  tk.filter_all = () => {
+    tk.reset_count();
+    const pane = current_pane();
+    const controller = pane?.commandController;
+    if (!controller) return "No message pane command controller";
+    controller.doCommand("cmd_viewAllMsgs");
+    pane.quickFilterBar?._resetFilterState?.();
+  };
+
+  window.tk_filter_unread = () => {
+    const error = tk.filter_unread();
+    if (error) window.alert(error);
+  };
+  window.tk_filter_all = () => {
+    const error = tk.filter_all();
+    if (error) window.alert(error);
+  };
+
   for (const name of Object.keys(tk.SORT_COLUMNS)) {
     window[`tk_sort_${name}`] = () => {
       tk.reset_count();

--- a/home/thunderbird/tbkeys/keys.json
+++ b/home/thunderbird/tbkeys/keys.json
@@ -55,7 +55,7 @@
   "g o": "func:tk_folder_picker",
   "g e": "func:tk_goto_extensions",
   "g c": "func:tk_goto_config",
-  "f u": "cmd:cmd_viewUnreadMsgs",
+  "f u": "func:tk_filter_unread",
   "f a": "func:tk_filter_all",
   "f s": "func:tk_toggle_starred_filter",
   "f f": "func:tk_filter_picker",


### PR DESCRIPTION
## Summary

- route `f u` and `:filter unread` through the current `about:3pane`
- use the Quick Filter Bar unread constraint for virtual/unified folders
- route `all` through the same controller and clear quick-filter state
- report missing message-pane controllers instead of silently doing nothing

## Validation

- `node --check` passed for the changed JavaScript files
- `jq empty` passed for `keys.json`
- focused ordinary/virtual routing checks passed
- `just check` remains blocked by unrelated pre-existing formatter drift

Closes #95,