### PR TITLE
feat: theme tbkeys UI with Thunderbird colors

### DIFF
--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -449,7 +449,7 @@
     el.id = "tbkeys-command-help";
     el.style.cssText =
       "position:fixed; right:12px; bottom:32px; z-index:2147483647; " +
-      `background:${tk.whichkey_colors.bg}; border:1px solid #333; ` +
+      `background:${tk.whichkey_colors.bg}; border:1px solid ${tk.whichkey_colors.border}; ` +
       "font:12px monospace; padding:6px 10px; pointer-events:none;";
     (doc.body ?? doc.documentElement).appendChild(el);
     return el;
@@ -550,8 +550,8 @@
     bar.style.cssText =
       "position:fixed; left:0; right:0; bottom:0; z-index:2147483647; " +
       "display:flex; flex-direction:column; align-items:stretch; " +
-      `background:${tk.whichkey_colors.bg}; border-top:1px solid #333; ` +
-      "font:12px monospace; color:#fff;";
+      `background:${tk.whichkey_colors.bg}; border-top:1px solid ${tk.whichkey_colors.border}; ` +
+      `font:12px monospace; color:${tk.whichkey_colors.label};`;
 
     const menu = doc.createElement("div");
     menu.id = "tbkeys-command-menu";
@@ -567,8 +567,8 @@
     input.type = "text";
     input.setAttribute("aria-label", "tbkeys command");
     input.style.cssText =
-      "flex:1; font:inherit; background:#222; color:#fff; " +
-      "border:1px solid #666; padding:2px 4px;";
+      `flex:1; font:inherit; background:${tk.whichkey_colors.bg}; color:${tk.whichkey_colors.label}; ` +
+      `border:1px solid ${tk.whichkey_colors.border}; padding:2px 4px;`;
     row.appendChild(label);
     row.appendChild(input);
 

--- a/home/thunderbird/.config/tbkeys/ui.js
+++ b/home/thunderbird/.config/tbkeys/ui.js
@@ -9,6 +9,12 @@
     insert: "-- INSERT --",
   };
 
+  const MODE_COLORS = {
+    normal: "var(--color-yellow-50)",
+    insert: "var(--color-red-50)",
+    visual: "var(--color-orange-50)",
+  };
+
   const QUICK_FILTER_ID = "qfb-qs-textbox";
 
   /**
@@ -46,6 +52,7 @@
       const pos = matches.length ? (window.folderSearchIndex ?? 0) + 1 : 0;
       parts.push(`/${tk.search_term} [${pos}/${matches.length}]`);
     }
+    el.style.color = MODE_COLORS[window.vim] ?? MODE_COLORS.normal;
     const text = parts.join(" ");
     if (el.namespaceURI?.includes("there.is.only.xul")) {
       el.setAttribute("value", text);

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -206,11 +206,12 @@
     "mail:3pane";
 
   tk.whichkey_colors = {
-    bg: "#0C0E13",
-    header: "#8A93A0",
-    key: "#D8CF7F",
-    group: "#FFA0A0",
-    label: "#B0C8DE",
+    bg: "var(--layout-background-0)",
+    header: "var(--color-gray-40)",
+    key: "var(--color-yellow-50)",
+    group: "var(--color-red-50)",
+    label: "var(--color-blue-30)",
+    border: "var(--color-gray-40)",
   };
 
   /**
@@ -224,7 +225,7 @@
     el.id = "tbkeys-whichkey";
     el.style.cssText =
       "position:fixed; right:12px; bottom:32px; z-index:2147483647; " +
-      `background:${tk.whichkey_colors.bg}; border:1px solid #333; ` +
+      `background:${tk.whichkey_colors.bg}; border:1px solid ${tk.whichkey_colors.border}; ` +
       "font:12px monospace; padding:6px 10px; " +
       "pointer-events:none; display:none;";
     (doc.body ?? doc.documentElement).appendChild(el);


### PR DESCRIPTION
## Summary

- color-code the persistent Vim mode indicator with Thunderbird CSS variables
- replace hard-coded which-key colors with Thunderbird's standard color variables
- use the active Thunderbird layout and border colors for tbkeys panels

Closes #91
