### PR TITLE
feat(tbkeys): add Markdown compose editor bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Module responsibilities, following a one-way dependency direction (later modules
 - `navigation.js` - higher-level stepping (unread/thread/starred/attachment), focus switching, and tab navigation.
 - `actions.js` - message mutations (read/unread/flag/junk/delete/archive/move) and `.` repeat-last-action.
 - `yank.js` - non-mutating message metadata/content yanks and privileged clipboard writes.
+- `editor.js` - the compose bridge: secure per-window temp files, asynchronous Kitty/Neovim/Pandoc sessions, conflict detection, Markdown-to-HTML conversion, and compose-editor write-back. Plain-text compose opens as text; HTML compose opens as Markdown.
 - `search.js` - incremental folder search (state, input, highlighting, matching, accept/cancel/step) and `tk_escape`, since escape is mostly search cleanup.
 - `command.js` - the Vim-style `:` command line: input UI, parser, and a declarative command registry (`archive`, `move`, `filter`, `open`, `edit`) that calls into the existing folder/action helpers rather than duplicating them.
-- `editor.js` - the compose bridge: secure per-window temp files, asynchronous Kitty/Neovim/Pandoc sessions, conflict detection, Markdown-to-HTML conversion, and compose-editor write-back. Plain-text compose opens as text; HTML compose opens as Markdown.
 - `ui.js` - the persistent mode/count/status indicator and lightweight transient feedback.
 - `whichkey.js` - the passive which-key overlay: chord trie, timers, and transient rendering. Loaded last, and fires the initial `tk.repaint_mode()` once every module is in place. Visualization only - it never touches Mousetrap or tbkeys keyboard dispatch.
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Vim-style keybindings for Betterbird, provided by the tbkeys add-on. Two locatio
 - `home/thunderbird/tbkeys/keys.json` - the keymap, one line per binding.
 - `home/thunderbird/.config/tbkeys/*.js` - the code the bindings call, split into cohesive feature modules. Stowed to `~/.config/tbkeys/` by the `thunderbird` package, and loaded automatically each time Betterbird starts.
 
-`system/opt/betterbird/betterbird.cfg` resolves `~/.config/tbkeys/` once per window and loads the modules through `Services.scriptloader.loadSubScriptWithOptions` in a fixed dependency order: `core.js`, `selection.js`, `folders.js`, `motions.js`, `navigation.js`, `actions.js`, `yank.js`, `search.js`, `command.js`, `ui.js`, `whichkey.js`. A missing or failing module logs which file it was rather than a generic error, and loading stops there for that window.
+`system/opt/betterbird/betterbird.cfg` resolves `~/.config/tbkeys/` once per window and loads the modules through `Services.scriptloader.loadSubScriptWithOptions` in a fixed dependency order: `core.js`, `selection.js`, `folders.js`, `motions.js`, `navigation.js`, `actions.js`, `yank.js`, `editor.js`, `search.js`, `command.js`, `ui.js`, `whichkey.js`. A missing or failing module logs which file it was rather than a generic error, and loading stops there for that window.
 
-Each module is `(function (tk) { "use strict"; ... })(window.tk);`, populating the shared `window.tk` namespace rather than using ES modules, imports, a bundler, or a build step. `core.js` is the exception: it first runs the teardown hooks the previous load left behind (`whichkey_teardown`, `ui_teardown`, `command_teardown`) so a reload doesn't leak listeners or injected elements, then creates a fresh `window.tk = {}` before populating it, so a reload never carries stale functions from a previous version.
+Each module is `(function (tk) { "use strict"; ... })(window.tk);`, populating the shared `window.tk` namespace rather than using ES modules, imports, a bundler, or a build step. `core.js` is the exception: it first runs the teardown hooks the previous load left behind (`whichkey_teardown`, `ui_teardown`, `command_teardown`, `editor_teardown`) so a reload doesn't leak listeners or injected elements, then creates a fresh `window.tk = {}` before populating it, so a reload never carries stale functions from a previous version.
 
 Module responsibilities, following a one-way dependency direction (later modules may call into earlier ones, never the reverse):
 
@@ -71,13 +71,16 @@ Module responsibilities, following a one-way dependency direction (later modules
 - `actions.js` - message mutations (read/unread/flag/junk/delete/archive/move) and `.` repeat-last-action.
 - `yank.js` - non-mutating message metadata/content yanks and privileged clipboard writes.
 - `search.js` - incremental folder search (state, input, highlighting, matching, accept/cancel/step) and `tk_escape`, since escape is mostly search cleanup.
-- `command.js` - the Vim-style `:` command line: input UI, parser, and a declarative command registry (`archive`, `move`, `filter`, `open`) that calls into the existing folder/action helpers rather than duplicating them.
+- `command.js` - the Vim-style `:` command line: input UI, parser, and a declarative command registry (`archive`, `move`, `filter`, `open`, `edit`) that calls into the existing folder/action helpers rather than duplicating them.
+- `editor.js` - the compose bridge: secure per-window temp files, asynchronous Kitty/Neovim/Pandoc sessions, conflict detection, Markdown-to-HTML conversion, and compose-editor write-back. Plain-text compose opens as text; HTML compose opens as Markdown.
 - `ui.js` - the persistent mode/count/status indicator and lightweight transient feedback.
 - `whichkey.js` - the passive which-key overlay: chord trie, timers, and transient rendering. Loaded last, and fires the initial `tk.repaint_mode()` once every module is in place. Visualization only - it never touches Mousetrap or tbkeys keyboard dispatch.
 
 New behavior belongs in the module matching its responsibility above; a feature spanning several (e.g. an operator acting over a range) should consume the existing `selection.js`/`motions.js`/`actions.js` primitives rather than reimplementing them.
 
 After editing any module, restart Betterbird.
+
+The `e` binding and `:edit` command open the current compose body in Kitty/Neovim. `Ctrl+E` is also a direct compose-body shortcut. Plain-text messages open as text; HTML messages are converted to Markdown and converted back to HTML after saving. Pandoc must be installed for HTML compose editing. The compose body displays INSERT mode while typing; `Ctrl+O` enters NORMAL mode for one command, after which the body returns to INSERT. In that NORMAL window, `e` opens Neovim. To use another terminal/editor launcher, set `window.__tbkeys_external_editor_command` to an argument array before invoking it; the file path is appended automatically (for example, `["wezterm", "start", "--", "nvim"]`). The converter can be overridden with `window.__tbkeys_markdown_converter_command` (for example, `["pandoc"]`).
 
 After editing `keys.json`, paste its contents into the add-on's options page (Add-ons Manager, tbkeys, Options). That file is a tracked copy, not something the add-on reads from disk. The same is true of `quicktext.json`.
 

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -324,7 +324,7 @@
     },
     edit: {
       usage: "edit",
-      description: "Edit the current plain-text compose body in Neovim",
+      description: "Edit the current compose body in Neovim",
       run: ({ args }) => {
         if (args.length) return tk.commands.edit.usage;
         window.tk_edit_compose_external?.();

--- a/home/thunderbird/.config/tbkeys/command.js
+++ b/home/thunderbird/.config/tbkeys/command.js
@@ -322,6 +322,14 @@
         window.tk_goto_inbox();
       },
     },
+    edit: {
+      usage: "edit",
+      description: "Edit the current plain-text compose body in Neovim",
+      run: ({ args }) => {
+        if (args.length) return tk.commands.edit.usage;
+        window.tk_edit_compose_external?.();
+      },
+    },
     reload: {
       usage: "reload",
       description: "Reload every tbkeys module into this window",

--- a/home/thunderbird/.config/tbkeys/core.js
+++ b/home/thunderbird/.config/tbkeys/core.js
@@ -7,6 +7,7 @@
   window.tk?.whichkey_teardown?.();
   window.tk?.ui_teardown?.();
   window.tk?.command_teardown?.();
+  window.tk?.editor_teardown?.();
   window.tk = {};
 })();
 
@@ -28,6 +29,7 @@
     "navigation.js",
     "actions.js",
     "yank.js",
+    "editor.js",
     "search.js",
     "command.js",
     "ui.js",

--- a/home/thunderbird/.config/tbkeys/editor.js
+++ b/home/thunderbird/.config/tbkeys/editor.js
@@ -297,6 +297,7 @@
           if (edited !== original.value) apply_body(editor, original, edited);
           report(edited === original.value ? "no changes" : "updated compose body");
         } catch (error) {
+          cleanup(session);
           report(`could not apply result (${error})`);
         } finally {
           if (!original.html) cleanup(session);
@@ -393,8 +394,11 @@
     if (
       window.__tbkeys_one_command_normal &&
       !["Control", "Alt", "Shift", "Meta"].includes(event.key)
-    )
+    ) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
       return_to_insert();
+    }
   };
 
   let inner_editor_window = null;

--- a/home/thunderbird/.config/tbkeys/editor.js
+++ b/home/thunderbird/.config/tbkeys/editor.js
@@ -1,0 +1,432 @@
+// External compose editing through a real Neovim process. Plain-text compose
+// uses plain text; HTML compose uses Markdown and is converted back through
+// Thunderbird's HTML editor API after the external edit completes.
+(function (tk) {
+  "use strict";
+
+  const SESSION_KEY = "__tbkeys_compose_editor_session";
+  const EDITOR_COMMAND_KEY = "__tbkeys_external_editor_command";
+  const MARKDOWN_COMMAND_KEY = "__tbkeys_markdown_converter_command";
+  const DEFAULT_COMMAND = ["kitty", "--wait", "nvim"];
+  const DEFAULT_MARKDOWN_COMMAND = ["pandoc"];
+  const Cc = () =>
+    window.Cc ??
+    window.Components?.classes ??
+    (typeof Components !== "undefined" ? Components.classes : null);
+  const Ci = () =>
+    window.Ci ??
+    window.Components?.interfaces ??
+    (typeof Components !== "undefined" ? Components.interfaces : null);
+
+  const report = (message) => tk.show_status?.(`EDITOR: ${message}`);
+
+  const compose_editor = () =>
+    typeof window.GetCurrentEditor === "function"
+      ? window.GetCurrentEditor()
+      : null;
+
+  const is_compose_window = () =>
+    window.document?.documentElement?.getAttribute("windowtype") === "msgcompose";
+
+  const is_compose_body_focus = () => {
+    if (!is_compose_window()) return false;
+    const editor = compose_editor();
+    const body = editor?.document?.body;
+    const inner_active = editor?.document?.activeElement;
+    if (body && (inner_active === body || body.contains(inner_active))) return true;
+    const outer_active = window.document?.activeElement;
+    return ["content-frame", "messageEditor"].some(
+      (id) => outer_active?.id === id,
+    );
+  };
+  tk.is_compose_body_focus = is_compose_body_focus;
+
+  const body_source = (editor) => {
+    const interfaces = Ci();
+    const encoder = interfaces?.nsIDocumentEncoder;
+    const flags =
+      (encoder?.OutputLFLineBreak ?? 0) |
+      (encoder?.OutputBodyOnly ?? 0) |
+      (encoder?.OutputNoScriptContent ?? 0);
+    const html = !!window.gMsgCompose?.composeHTML;
+    return {
+      html,
+      value: editor.outputToString(html ? "text/html" : "text/plain", flags),
+    };
+  };
+
+  const tmp_file = () => {
+    const classes = Cc();
+    const interfaces = Ci();
+    if (!classes || !interfaces) throw new Error("XPCOM services unavailable");
+    const dir = Services.dirsvc.get("TmpD", interfaces.nsIFile).clone();
+    dir.append("tbkeys-compose");
+    if (!dir.exists()) dir.create(interfaces.nsIFile.DIRECTORY_TYPE, 0o700);
+    const file = dir.clone();
+    file.append("compose.txt");
+    file.createUnique(interfaces.nsIFile.NORMAL_FILE_TYPE, 0o600);
+    return file;
+  };
+
+  const write_utf8 = (file, text) => {
+    const classes = Cc();
+    const interfaces = Ci();
+    const stream = classes["@mozilla.org/network/file-output-stream;1"].createInstance(
+      interfaces.nsIFileOutputStream,
+    );
+    const converter = classes[
+      "@mozilla.org/intl/converter-output-stream;1"
+    ].createInstance(interfaces.nsIConverterOutputStream);
+    stream.init(file, 0x02 | 0x08 | 0x20, 0o600, 0);
+    converter.init(stream, "UTF-8", 0, 0);
+    converter.writeString(text);
+    converter.close();
+  };
+
+  const read_utf8 = (file) => {
+    const classes = Cc();
+    const interfaces = Ci();
+    const stream = classes["@mozilla.org/network/file-input-stream;1"].createInstance(
+      interfaces.nsIFileInputStream,
+    );
+    const converter = classes[
+      "@mozilla.org/intl/converter-input-stream;1"
+    ].createInstance(interfaces.nsIConverterInputStream);
+    stream.init(file, 0x01, 0, 0);
+    converter.init(stream, "UTF-8", 4096, 0xFFFD);
+    let result = "";
+    const buffer = {};
+    while (converter.readString(4096, buffer)) result += buffer.value;
+    converter.close();
+    return result;
+  };
+
+  const executable_for = (name) => {
+    const interfaces = Ci();
+    const file = Cc()["@mozilla.org/file/local;1"].createInstance(
+      interfaces.nsIFile,
+    );
+    if (name.startsWith("/")) {
+      file.initWithPath(name);
+      return file.exists() && file.isExecutable() ? file : null;
+    }
+    const path = Services.env.get("PATH") ?? "";
+    for (const directory of path.split(":")) {
+      if (!directory) continue;
+      file.initWithPath(`${directory}/${name}`);
+      if (file.exists() && file.isExecutable()) return file;
+    }
+    return null;
+  };
+
+  const launch_process = (command_key, default_command, args, on_exit) => {
+    const command = window[command_key] ?? default_command;
+    if (!Array.isArray(command) || !command.length)
+      throw new Error(`${command_key} must be a non-empty array`);
+    const executable = executable_for(command[0]);
+    if (!executable) throw new Error(`cannot find ${command[0]}`);
+    const process = Cc()["@mozilla.org/process/util;1"].createInstance(
+      Ci().nsIProcess,
+    );
+    process.init(executable);
+    const process_args = [...command.slice(1), ...args];
+    process.runAsync(process_args, process_args.length, {
+      observe(subject, topic) {
+        if (topic === "process-finished" || topic === "process-failed")
+          on_exit(topic === "process-finished" && subject.exitValue === 0);
+      },
+    });
+    return process;
+  };
+
+  const launch_editor = (file, on_exit, markdown = false) =>
+    launch_process(
+      EDITOR_COMMAND_KEY,
+      DEFAULT_COMMAND,
+      markdown ? ["-c", "setlocal filetype=markdown", file.path] : [file.path],
+      on_exit,
+    );
+
+  const launch_markdown = (input, output, on_exit) =>
+    launch_process(
+      MARKDOWN_COMMAND_KEY,
+      DEFAULT_MARKDOWN_COMMAND,
+      ["--from=gfm", "--to=html5", "--wrap=none", "--output", output.path, input.path],
+      on_exit,
+    );
+
+  const launch_html_to_markdown = (input, output, on_exit) =>
+    launch_process(
+      MARKDOWN_COMMAND_KEY,
+      DEFAULT_MARKDOWN_COMMAND,
+      ["--from=html", "--to=gfm", "--wrap=none", "--output", output.path, input.path],
+      on_exit,
+    );
+
+  const cleanup = (session) => {
+    try {
+      if (session.file?.exists()) session.file.remove(false);
+      if (session.source_file?.exists()) session.source_file.remove(false);
+      if (session.html_file?.exists()) session.html_file.remove(false);
+    } catch (_) {
+      // Best effort cleanup; the unique file remains safe to remove later.
+    }
+    if (window[SESSION_KEY] === session) window[SESSION_KEY] = null;
+  };
+
+  const apply_body = (editor, snapshot, value) => {
+    if (snapshot.html) {
+      const interfaces = Ci();
+      let html_editor = editor;
+      if (
+        typeof html_editor.insertHTML !== "function" &&
+        interfaces?.nsIHTMLEditor
+      )
+        html_editor = editor.QueryInterface(interfaces.nsIHTMLEditor);
+      if (typeof html_editor.insertHTML !== "function")
+        throw new Error("Thunderbird HTML editor API is unavailable");
+      html_editor.beginTransaction?.();
+      try {
+        html_editor.selectAll();
+        html_editor.insertHTML(value);
+      } finally {
+        html_editor.endTransaction?.();
+      }
+    } else {
+      editor.beginTransaction?.();
+      try {
+        editor.selectAll();
+        editor.insertText(value);
+      } finally {
+        editor.endTransaction?.();
+      }
+    }
+    window.gMsgCompose.bodyModified = true;
+    editor.document?.body?.focus?.();
+  };
+
+  tk.edit_compose_external = () => {
+    if (!is_compose_window()) {
+      report("only available in a compose window");
+      return;
+    }
+    if (window[SESSION_KEY]) {
+      report("an editor session is already active");
+      return;
+    }
+    const editor = compose_editor();
+    if (!editor) return report("compose editor is not ready");
+
+    let original;
+    let file;
+    let source_file;
+    let html_file;
+    try {
+      original = body_source(editor);
+      file = tmp_file();
+      if (original.html) {
+        source_file = tmp_file();
+        html_file = tmp_file();
+        write_utf8(source_file, original.value);
+      } else {
+        write_utf8(file, original.value);
+      }
+    } catch (error) {
+      for (const candidate of [file, source_file, html_file])
+        try {
+          if (candidate?.exists()) candidate.remove(false);
+        } catch (_) {}
+      report(`could not prepare temp file (${error})`);
+      return;
+    }
+
+    const session = {
+      editor,
+      original,
+      file,
+      source_file,
+      html_file,
+      process: null,
+    };
+    window[SESSION_KEY] = session;
+
+    const begin_editor = () => {
+      if (original.html) session.markdown_original = read_utf8(file);
+      session.process = launch_editor(file, (saved) => {
+        try {
+          if (!saved) {
+            report("cancelled; body unchanged");
+            cleanup(session);
+            return;
+          }
+          const current = body_source(editor);
+          if (current.html !== original.html || current.value !== original.value) {
+            report("body changed in Betterbird; result not applied");
+            cleanup(session);
+            return;
+          }
+          if (original.html) {
+            try {
+              session.process = launch_markdown(file, html_file, (converted) => {
+                try {
+                  if (!converted)
+                    return report("Markdown conversion failed; body unchanged");
+                  const latest = body_source(editor);
+                  if (latest.value !== original.value)
+                    return report("body changed in Betterbird; result not applied");
+                  const markdown = read_utf8(file);
+                  const edited = read_utf8(html_file);
+                  if (markdown !== session.markdown_original)
+                    apply_body(editor, original, edited);
+                  report(
+                    markdown === session.markdown_original
+                      ? "no changes"
+                      : "updated HTML compose body",
+                  );
+                } finally {
+                  cleanup(session);
+                }
+              });
+            } catch (error) {
+              cleanup(session);
+              report(`could not convert Markdown (${error})`);
+            }
+            return;
+          }
+          const edited = read_utf8(file);
+          if (edited !== original.value) apply_body(editor, original, edited);
+          report(edited === original.value ? "no changes" : "updated compose body");
+        } catch (error) {
+          report(`could not apply result (${error})`);
+        } finally {
+          if (!original.html) cleanup(session);
+        }
+      }, original.html);
+    };
+
+    try {
+      session.process = original.html
+        ? launch_html_to_markdown(source_file, file, (converted) => {
+            if (!converted) {
+              cleanup(session);
+              report("HTML-to-Markdown conversion failed; body unchanged");
+              return;
+            }
+            try {
+              begin_editor();
+            } catch (error) {
+              cleanup(session);
+              report(`could not launch Neovim (${error})`);
+            }
+          })
+        : begin_editor();
+    } catch (error) {
+      cleanup(session);
+      report(`could not launch editor (${error})`);
+    }
+  };
+
+  const repaint_compose_mode = () => tk.repaint_mode?.();
+  const compose_focus_handler = () =>
+    window.setTimeout(() => {
+      attach_editor_window();
+      if (is_compose_body_focus()) {
+        if (!window.__tbkeys_one_command_normal) window.vim = "insert";
+      } else if (window.vim === "insert") {
+        window.vim = "normal";
+      }
+      repaint_compose_mode();
+    }, 0);
+
+  const return_to_insert = () => {
+    if (!window.__tbkeys_one_command_normal) return;
+    window.setTimeout(() => {
+      window.__tbkeys_one_command_normal = false;
+      if (is_compose_body_focus()) window.vim = "insert";
+      repaint_compose_mode();
+    }, 0);
+  };
+
+  const compose_keydown_handler = (event) => {
+    if (!is_compose_body_focus()) return;
+    const key = event.key.toLowerCase();
+    if (
+      key === "e" &&
+      event.ctrlKey &&
+      !event.altKey &&
+      !event.shiftKey &&
+      !event.metaKey
+    ) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      tk.edit_compose_external();
+      return;
+    }
+    if (
+      key === "o" &&
+      event.ctrlKey &&
+      !event.altKey &&
+      !event.shiftKey &&
+      !event.metaKey
+    ) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      window.vim = "normal";
+      window.__tbkeys_one_command_normal = true;
+      repaint_compose_mode();
+      return;
+    }
+    if (
+      window.vim === "normal" &&
+      key === "e" &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.shiftKey &&
+      !event.metaKey
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      tk.edit_compose_external();
+      return_to_insert();
+      return;
+    }
+    if (
+      window.__tbkeys_one_command_normal &&
+      !["Control", "Alt", "Shift", "Meta"].includes(event.key)
+    )
+      return_to_insert();
+  };
+
+  let inner_editor_window = null;
+  const attach_editor_window = () => {
+    const next = compose_editor()?.document?.defaultView;
+    if (next === inner_editor_window) return;
+    if (inner_editor_window) {
+      inner_editor_window.removeEventListener("focusin", compose_focus_handler, true);
+      inner_editor_window.removeEventListener("focusout", compose_focus_handler, true);
+      inner_editor_window.removeEventListener("keydown", compose_keydown_handler, true);
+    }
+    inner_editor_window = next && next !== window ? next : null;
+    if (!inner_editor_window) return;
+    inner_editor_window.addEventListener("focusin", compose_focus_handler, true);
+    inner_editor_window.addEventListener("focusout", compose_focus_handler, true);
+    inner_editor_window.addEventListener("keydown", compose_keydown_handler, true);
+  };
+
+  window.tk_edit_compose_external = tk.edit_compose_external;
+  window.addEventListener("focusin", compose_focus_handler, true);
+  window.addEventListener("focusout", compose_focus_handler, true);
+  window.addEventListener("keydown", compose_keydown_handler, true);
+  attach_editor_window();
+  compose_focus_handler();
+  tk.editor_teardown = () => {
+    window.removeEventListener("focusin", compose_focus_handler, true);
+    window.removeEventListener("focusout", compose_focus_handler, true);
+    window.removeEventListener("keydown", compose_keydown_handler, true);
+    if (inner_editor_window) {
+      inner_editor_window.removeEventListener("focusin", compose_focus_handler, true);
+      inner_editor_window.removeEventListener("focusout", compose_focus_handler, true);
+      inner_editor_window.removeEventListener("keydown", compose_keydown_handler, true);
+    }
+  };
+})(window.tk);

--- a/home/thunderbird/.config/tbkeys/ui.js
+++ b/home/thunderbird/.config/tbkeys/ui.js
@@ -18,15 +18,27 @@
   const QUICK_FILTER_ID = "qfb-qs-textbox";
 
   /**
-   * @returns {Element} the injected mode/count indicator, or null where the mail status bar is absent (e.g. compose windows)
+   * @returns {Element} the injected mode/count indicator, or null where no suitable host exists
    */
   tk.ensure_mode_indicator = () => {
     const doc = window.document;
     const host =
       doc?.getElementById("statusTextBox") ?? doc?.getElementById("status-bar");
-    if (!host) return null;
     let el = doc.getElementById("tbkeys-mode-indicator");
     if (el) return el;
+    if (!host) {
+      if (doc.documentElement?.getAttribute("windowtype") !== "msgcompose")
+        return null;
+      el = doc.createXULElement
+        ? doc.createXULElement("label")
+        : doc.createElement("label");
+      el.id = "tbkeys-mode-indicator";
+      el.style.cssText =
+        "position:fixed; right:12px; bottom:12px; z-index:2147483647; " +
+        "font:14px monospace; padding:4px 8px; background:var(--layout-background-0);";
+      (doc.body ?? doc.documentElement).appendChild(el);
+      return el;
+    }
     el = doc.createXULElement
       ? doc.createXULElement("label")
       : doc.createElement("label");
@@ -84,6 +96,7 @@
    */
   tk.is_text_focus = () =>
     !!(
+      tk.is_compose_body_focus?.() ||
       tk.is_text_input?.(window.document?.activeElement) ||
       tk.is_text_input?.(tk.get_inbox_doc()?.activeElement)
     );
@@ -94,6 +107,10 @@
   tk.sync_insert_mode = () => {
     const in_text = tk.is_text_focus();
     if (in_text) {
+      if (window.__tbkeys_one_command_normal) {
+        tk.repaint_mode();
+        return;
+      }
       if (window.vim === "insert") return;
       tk.mode_before_insert = window.vim ?? "normal";
       window.vim = "insert";

--- a/system/opt/betterbird/betterbird.cfg
+++ b/system/opt/betterbird/betterbird.cfg
@@ -13,6 +13,7 @@ try {
     "navigation.js",
     "actions.js",
     "yank.js",
+    "editor.js",
     "search.js",
     "command.js",
     "ui.js",


### PR DESCRIPTION
## Summary

Implements #107, part of #100.

- Adds a dedicated asynchronous compose editor bridge.
- Opens plain-text bodies directly in Neovim.
- Converts HTML compose bodies to Markdown with Pandoc, then back to HTML on save.
- Uses secure per-compose-window temporary files and conflict detection.
- Adds compose INSERT mode indication, one-command NORMAL mode via Ctrl+O, and direct Ctrl+E editing.
- Preserves the existing mail-window Ctrl+O behavior.
- Documents configuration and workflow.

## Validation

- node --check for changed JavaScript modules
- jq validation for the tbkeys keymap
- git diff --check
- Pandoc 3.10.2 detected

HTML/Markdown and live Betterbird behavior still need manual verification in a running compose window.