### PR TITLE
feat(yazi): add keybind to open btop

### DIFF
--- a/home/yazi/.config/yazi/keymap.toml
+++ b/home/yazi/.config/yazi/keymap.toml
@@ -54,6 +54,7 @@ prepend_keymap = [
   { on = ["i", "i"], run = 'shell --block -- stat %h; echo; file %h; echo; read -n 1 -s -r -p "Press any key..."', desc = "Inspect file" },
   { on = ["i", "r"], run = "shell --block -- %h", desc = "Run executable" },
   { on = ["i", "R"], run = "shell --orphan -- %h", desc = "Run executable detached" },
+  { on = ["i", "t"], run = "shell --block -- btop", desc = "Open btop" },
 
   # Mount
   { on = [ "M", "m", ], run = "plugin mount", desc = "Open Mount Options" },


### PR DESCRIPTION
## Summary
- Adds an `i t` keybind to `home/yazi/.config/yazi/keymap.toml` that runs `shell --block -- btop`, alongside the other `i` bindings in the "In..." section.
- Uses `--block` so yazi waits for btop to exit (matching the existing `i d` gdu disk-usage binding), returning to yazi when btop is quit with `q`.

Closes #113

## Notes
- Verified the new entry doesn't conflict with any existing `i` binding in the file (`i d`, `i e`, `i i`, `i r`, `i R`).
- Verified the TOML still parses correctly after the change.
- Ran `codex exec` against the diff for an independent review: no findings. Codex confirmed the `["i", "t"]` binding is unique, uses valid shell-command syntax matching existing entries, and `btop` is already a tracked package dependency (`packages/arch.ini`).

## Test plan
- [ ] Manually press `i` then `t` in yazi and confirm btop launches, blocking yazi until quit with `q`.