### PR TITLE
fix(tbkeys): ignore standalone modifier keydowns in which-key handler

### DIFF
--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -362,6 +362,29 @@
     tk.hide_whichkey();
   };
 
+  // Standalone modifier keydowns (fired when the modifier itself is
+  // pressed, e.g. holding Shift before the character key lands) per the
+  // UI Events KeyboardEvent.key modifier key values. None of these are
+  // ever a trie key or a real chord step, so they must not be treated as
+  // an unmatched key and must not abort an in-progress chord.
+  const WHICHKEY_MODIFIER_KEYS = new Set([
+    "Alt",
+    "AltGraph",
+    "CapsLock",
+    "Control",
+    "Fn",
+    "FnLock",
+    "Hyper",
+    "Meta",
+    "NumLock",
+    "ScrollLock",
+    "Shift",
+    "Super",
+    "Symbol",
+    "SymbolLock",
+    "OS",
+  ]);
+
   /**
    * Capture-phase keydown observer that mirrors chord progress into the
    * which-key panel and suppresses a chord leader's native Thunderbird
@@ -370,6 +393,7 @@
    */
   tk.whichkey_handler = (e) => {
     tk.sync_insert_mode?.();
+    if (WHICHKEY_MODIFIER_KEYS.has(e.key)) return;
     if (
       e.ctrlKey ||
       e.altKey ||

--- a/home/thunderbird/.config/tbkeys/whichkey.js
+++ b/home/thunderbird/.config/tbkeys/whichkey.js
@@ -393,7 +393,6 @@
    */
   tk.whichkey_handler = (e) => {
     tk.sync_insert_mode?.();
-    if (WHICHKEY_MODIFIER_KEYS.has(e.key)) return;
     if (
       e.ctrlKey ||
       e.altKey ||
@@ -414,6 +413,7 @@
       tk.abort_chord();
       return;
     }
+    if (WHICHKEY_MODIFIER_KEYS.has(e.key)) return;
     if (e.key === "?" && tk.whichkey_node === tk.whichkey_trie) {
       // No auto-hide timer - this is a reference list to read, dismissed
       // only by Esc or the next keypress (handled above).


### PR DESCRIPTION
## Problem

`tk.whichkey_handler` in `home/thunderbird/.config/tbkeys/whichkey.js` treated any keydown with no matching trie child as a failed chord step and aborted the chord. It never distinguished a standalone modifier keydown (`Shift`, `Control`, `Alt`, `Meta`, `CapsLock`, etc., which fire their own `keydown` when the modifier itself is pressed) from a real character key.

Example: `[` opens the folder-navigation which-key list; `U` is bound as `[ U` ("previous unread, any folder"), which requires holding Shift. Shift's own keydown (`e.key === "Shift"`) arrived first, wasn't caught by the existing ctrl/alt/meta guard, had no trie child, and fell into the "no match" branch — closing the panel and aborting the chord before the `U` keydown ever landed.

## Fix

Added a `WHICHKEY_MODIFIER_KEYS` set covering the standalone modifier values from the UI Events `KeyboardEvent.key` spec (`Alt`, `AltGraph`, `CapsLock`, `Control`, `Fn`, `FnLock`, `Hyper`, `Meta`, `NumLock`, `ScrollLock`, `Shift`, `Super`, `Symbol`, `SymbolLock`, `OS`), and an early return in `tk.whichkey_handler` when `e.key` is in that set — no abort, no state change, chord/which-key panel survives until the real character keydown.

Real modifier **combos** (e.g. Ctrl+something) are untouched: those events carry a non-modifier `e.key` with `e.ctrlKey`/`altKey`/`metaKey` set, so they still hit the existing modifier-flag guard and still abort the chord as before.

## Codex review + follow-up fix

Ran `codex exec` (read-only) against the diff of the original fix (`ad0893c`). It flagged a real regression: the modifier early-return was placed *before* the `whichkey_full_shown` check ("any key dismisses the full `?` list"), so pressing a lone modifier (e.g. Shift) while the full command-list overlay was open no longer dismissed it — a stuck-panel edge case reintroduced by the original fix.

Follow-up commit moves the modifier early-return to *after* the `whichkey_full_shown` dismissal check, so:
- A lone modifier keydown still dismisses the full `?` list, same as any other key.
- A lone modifier keydown still does not abort an in-progress chord or get treated as an unmatched trie key.

Codex's other observations on the original diff were confirmed correct and needed no changes: Ctrl+`<key>` combos still abort as before; text-input guard behavior is unchanged; `whichkey_timer` is untouched by modifier keydowns, so an active chord still expires on its original 1000ms schedule.

## Testing

- `node --check` on the modified file: passes.
- `sh ./lib/check.sh` (repo's validation script): passes.
- No automated test harness exists for tbkeys (confirmed by the issue itself). **Manual verification in a live Thunderbird/Betterbird window has not been performed in this environment** and still needs to happen before merge, per the issue's acceptance criteria:
  1. `[` then hold Shift, press `U` → panel should survive the Shift keydown, `[ U` should fire `tk_prev_unread_any_folder`.
  2. Same for another shift-combo chord step (e.g. `shift+h`/`shift+l`, `whichkey.js:159-160`).
  3. Escape, an actual unmatched non-modifier key, and Ctrl/Alt/Meta combos should still abort the chord as before.
  4. `suppress_keypress` / native-shortcut suppression for leader keys with children should be unaffected (this diff doesn't touch that code path).
  5. Opening the `?` full command list, then pressing a lone modifier (e.g. Shift), should still dismiss the list (regression covered by the follow-up commit).

## Attention for reviewers

Live manual verification (acceptance criteria above) has not been done and should happen before merge.
